### PR TITLE
ci: Add security-events permission for SARIF upload

### DIFF
--- a/.github/workflows/powershell-lint.yml
+++ b/.github/workflows/powershell-lint.yml
@@ -15,6 +15,10 @@ on:
             - "**.psd1"
     workflow_dispatch: # Allow manual trigger for baseline scans
 
+permissions:
+    contents: read
+    security-events: write  # Required for SARIF upload to code scanning
+
 jobs:
     lint:
         name: PSScriptAnalyzer


### PR DESCRIPTION
Fixes permission error when uploading SARIF to code scanning