### PR TITLE
fix: resolve Get-AzureEndpoints function call order error (v1.5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.1] - 2026-02-04
+
+### Fixed
+- **Function definition order** - Fixed `Get-AzureEndpoints` function being called before it was defined, causing "term not recognized" error on script startup
+  - Moved Azure endpoints initialization to after all function definitions
+  - Script now executes correctly without errors
+
 ## [1.5.0] - 2026-02-03
 
 ### Added

--- a/Get-AzVMAvailability.ps1
+++ b/Get-AzVMAvailability.ps1
@@ -204,7 +204,7 @@ $ProgressPreference = 'SilentlyContinue'  # Suppress progress bars for faster ex
 
 # === Configuration ==================================================
 # Script metadata
-$ScriptVersion = "1.5.0"
+$ScriptVersion = "1.5.1"
 
 # Map parameters to internal variables
 $TargetSubIds = $SubscriptionId
@@ -249,9 +249,7 @@ if ($Environment) {
     $script:TargetEnvironment = $Environment
 }
 
-# Initialize Azure endpoints for environment-aware URLs (quota portal, pricing API)
-# This ensures sovereign cloud users get correct URLs even without -ShowPricing
-$script:AzureEndpoints = Get-AzureEndpoints -EnvironmentName $script:TargetEnvironment
+# Note: Azure endpoints initialized after function definitions (see below "Initialize Azure endpoints")
 
 # Detect execution environment (Azure Cloud Shell vs local)
 $isCloudShell = $env:CLOUD_SHELL -eq "true" -or (Test-Path "/home/system" -ErrorAction SilentlyContinue)
@@ -1022,6 +1020,11 @@ function Format-FixedWidthTable {
         Write-Host ($rowParts -join '  ') -ForegroundColor $rowColor
     }
 }
+
+# === Initialize Azure Endpoints =====================================
+# Must be after function definitions, before main execution
+# This ensures sovereign cloud users get correct URLs (quota portal, pricing API)
+$script:AzureEndpoints = Get-AzureEndpoints -EnvironmentName $script:TargetEnvironment
 
 # === Interactive Prompts ============================================
 # Prompt user for subscription(s) if not provided via parameters

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A PowerShell tool for checking Azure VM SKU availability across regions - find w
 ![PowerShell](https://img.shields.io/badge/PowerShell-7.0%2B-blue)
 ![Azure](https://img.shields.io/badge/Azure-Az%20Modules-0078D4)
 ![License](https://img.shields.io/badge/License-MIT-green)
-![Version](https://img.shields.io/badge/Version-1.5.0-brightgreen)
+![Version](https://img.shields.io/badge/Version-1.5.1-brightgreen)
 
 ## Overview
 


### PR DESCRIPTION
## 🐛 Bug Fix: Function Definition Order

### Problem

Script failed on startup with error:

```
Get-AzureEndpoints: The term 'Get-AzureEndpoints' is not recognized as a name of a cmdlet, function, script file, or executable program.
```

### Root Cause

The `Get-AzureEndpoints` function was being called at line 254 (in the configuration section) before it was defined at line 341. PowerShell parses scripts top-to-bottom, so functions must be defined before they're called.

### Fix

Moved the Azure endpoints initialization to **after** all function definitions, right before the interactive prompts section.

### Changes

- `Get-AzVMAvailability.ps1`: Relocated endpoint initialization (line ~1025)
- `CHANGELOG.md`: Added v1.5.1 entry
- `README.md`: Updated version badge to 1.5.1

### Testing

- ✅ Script now executes without errors
- ✅ All existing functionality preserved
