### PR TITLE
fix: use exact SKU .Family key for quota lookup (#25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.3] - 2026-03-04
+
+### Fixed
+- **Quota column now shows correct per-SKU family quota** — previously matched the broad family bucket (e.g., `Standard NC Family vCPUs`) instead of the specific sub-family (e.g., `Standard NCADS_A100_v4 Family vCPUs`), causing the tool to report available quota for GPU/HPC SKUs that actually had zero quota. Now uses each SKU's `.Family` property as an exact hash key into the quota data, eliminating regex-based matching entirely. Fixes #25.
+- Built per-region quota lookup hash table for O(1) quota resolution instead of linear regex search per SKU.
+
 ## [1.10.2] - 2026-03-03
 
 ### Fixed

--- a/Get-AzVMAvailability.ps1
+++ b/Get-AzVMAvailability.ps1
@@ -123,7 +123,7 @@
     Author:         Zachary Luz
     Company:        Microsoft
     Created:        2026-01-21
-    Version:        1.10.2
+    Version:        1.10.3
     License:        MIT
     Repository:     https://github.com/zacharyluz/Get-AzVMAvailability
 
@@ -317,7 +317,7 @@ foreach ($paramName in @('SubscriptionId', 'Region', 'FamilyFilter', 'SkuFilter'
 }
 
 #region Configuration
-$ScriptVersion = "1.10.2"
+$ScriptVersion = "1.10.3"
 
 #region Constants
 $HoursPerMonth = 730
@@ -967,8 +967,8 @@ function Format-RegionList {
 }
 
 function Get-QuotaAvailable {
-    param([object[]]$Quotas, [string]$FamilyName, [int]$RequiredvCPUs = 0)
-    $quota = $Quotas | Where-Object { $_.Name.LocalizedValue -match $FamilyName } | Select-Object -First 1
+    param([hashtable]$QuotaLookup, [string]$SkuFamily, [int]$RequiredvCPUs = 0)
+    $quota = $QuotaLookup[$SkuFamily]
     if (-not $quota) { return @{ Available = $null; OK = $null; Limit = $null; Current = $null } }
     $available = $quota.Limit - $quota.CurrentValue
     return @{
@@ -2614,6 +2614,8 @@ foreach ($subscriptionData in $allSubscriptionData) {
         }
 
         $familyGroups = @{}
+        $quotaLookup = @{}
+        foreach ($q in $data.Quotas) { $quotaLookup[$q.Name.Value] = $q }
         foreach ($sku in $data.Skus) {
             $family = Get-SkuFamily $sku.Name
             if (-not $familyGroups[$family]) { $familyGroups[$family] = @() }
@@ -2666,7 +2668,7 @@ foreach ($subscriptionData in $allSubscriptionData) {
             $restrictions = Get-RestrictionDetails $largestSku.Sku
             $capacity = $restrictions.Status
             $zoneStatus = Format-ZoneStatus $restrictions.ZonesOK $restrictions.ZonesLimited $restrictions.ZonesRestricted
-            $quotaInfo = Get-QuotaAvailable -Quotas $data.Quotas -FamilyName "Standard $family*"
+            $quotaInfo = Get-QuotaAvailable -QuotaLookup $quotaLookup -SkuFamily $largestSku.Sku.Family
 
             # Get pricing - find smallest SKU with pricing available
             $priceHrStr = '-'
@@ -2713,6 +2715,9 @@ foreach ($subscriptionData in $allSubscriptionData) {
             foreach ($sku in $skus) {
                 $familySkuIndex[$family][$sku.Name] = $true
                 $skuRestrictions = Get-RestrictionDetails $sku
+
+                # Per-SKU quota: use SKU's exact .Family property for specific quota bucket
+                $quotaInfo = Get-QuotaAvailable -QuotaLookup $quotaLookup -SkuFamily $sku.Family
 
                 # Get individual SKU pricing
                 $skuPriceHr = '-'

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A PowerShell tool for checking Azure VM SKU availability across regions - find w
 ![PowerShell](https://img.shields.io/badge/PowerShell-7.0%2B-blue)
 ![Azure](https://img.shields.io/badge/Azure-Az%20Modules-0078D4)
 ![License](https://img.shields.io/badge/License-MIT-green)
-![Version](https://img.shields.io/badge/Version-1.10.2-brightgreen)
+![Version](https://img.shields.io/badge/Version-1.10.3-brightgreen)
 
 ## Disclosure & Disclaimer
 
@@ -351,7 +351,7 @@ SKUs that are available but **incompatible** with your image are shown in dark y
 ### Console Output (with Pricing)
 ```
 ====================================================================================
-GET-AZVMAVAILABILITY v1.10.2
+GET-AZVMAVAILABILITY v1.10.3
 ====================================================================================
 SKU Filter: Standard_D2s_v5 | Pricing: Enabled
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-## Current Release: v1.10.2
+## Current Release: v1.10.3
 
 See [CHANGELOG.md](CHANGELOG.md) for full version history.
 


### PR DESCRIPTION
## Summary

Fixes #25 — Quota column now shows the correct per-SKU family quota instead of the broad family bucket.

## Problem

`Get-QuotaAvailable` used `-match` with a regex pattern like `"Standard NC*"` to find quota entries. This matched the **broad** `Standard NC Family vCPUs` (limit=48) instead of the **specific** `Standard NCADS_A100_v4 Family vCPUs` (limit=0). Users saw available quota for GPU/HPC SKUs that actually had zero quota.

## Root Cause

The `-match` operator with `Select-Object -First 1` grabbed the first regex hit in API return order, which was always the broad family entry. SKUs within the same letter group (NC) can belong to completely different quota sub-families.

## Fix

- Replace regex matching with a **hash table** keyed by the quota entry's `.Name.Value`
- Look up each SKU's quota using its `.Family` property as the exact hash key
- Build the hash table once per region (zero additional API calls)
- Per-SKU drill-down rows now each resolve their own specific quota bucket

## Changes

- `Get-QuotaAvailable` — params changed from `$Quotas/$FamilyName` to `$QuotaLookup/$SkuFamily`; direct hash lookup replaces regex
- Region processing loop — builds `$quotaLookup` hash table after quota data loads
- Family summary row — uses largest SKU's `.Family` for representative quota
- Per-SKU detail loop — each SKU resolves its own quota via `$sku.Family`
- Version bump: 1.10.2 → 1.10.3
- CHANGELOG, README, ROADMAP updated

## Validation

- `.\tools\Validate-Script.ps1` — all checks pass (syntax, AI-comment scan, version consistency)
- PSScriptAnalyzer and Pester skipped (not installed on build machine; CI will run them)

## Checklist

- [x] No subscription IDs, tenant IDs, or secrets in the PR
- [x] Changelog updated
- [x] Version bumped consistently across all files
- [x] Validate-Script.ps1 passes
