### PR TITLE
fix: display quota 0 instead of ? in family summary table

### DIFF
--- a/.github/skills/release-process-guardrails/SKILL.md
+++ b/.github/skills/release-process-guardrails/SKILL.md
@@ -20,10 +20,11 @@ applyTo: "**/*"
 ## Checklist
 1) Ensure PR exists for release changes
 2) Wait for CI (PSScriptAnalyzer, Pester) to finish successfully
-3) Merge via squash (unless policy says otherwise)
-4) Sync local `main` to `origin/main`
-5) Tag release on the merge commit
-6) Create/verify GitHub release notes
+3) Pull and triage GitHub Copilot PR review comments before merge
+4) Merge via squash (unless policy says otherwise)
+5) Sync local `main` to `origin/main`
+6) Tag release on the merge commit
+7) Create/verify GitHub release notes
 
 ## Common pitfalls
 - Tagging or publishing before PR merge (tags point to local-only commits)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.4] - 2026-03-04
+
+### Fixed
+- **Family summary Quota column now correctly displays `0`** — the truthiness check `if ($quotaInfo.Available)` treated `0` as falsy and showed `?` instead. Changed to explicit null check `if ($null -ne $quotaInfo.Available)` to match the per-SKU drill-down logic. Discovered via Copilot PR review triage on #26.
+
 ## [1.10.3] - 2026-03-04
 
 ### Fixed

--- a/Get-AzVMAvailability.ps1
+++ b/Get-AzVMAvailability.ps1
@@ -123,7 +123,7 @@
     Author:         Zachary Luz
     Company:        Microsoft
     Created:        2026-01-21
-    Version:        1.10.3
+    Version:        1.10.4
     License:        MIT
     Repository:     https://github.com/zacharyluz/Get-AzVMAvailability
 
@@ -317,7 +317,7 @@ foreach ($paramName in @('SubscriptionId', 'Region', 'FamilyFilter', 'SkuFilter'
 }
 
 #region Configuration
-$ScriptVersion = "1.10.3"
+$ScriptVersion = "1.10.4"
 
 #region Constants
 $HoursPerMonth = 730
@@ -2699,7 +2699,7 @@ foreach ($subscriptionData in $allSubscriptionData) {
                 Largest = "{0}vCPU/{1}GB" -f $largestSku.vCPU, $largestSku.Memory
                 Zones   = $zoneStatus
                 Status  = $capacity
-                Quota   = if ($quotaInfo.Available) { $quotaInfo.Available } else { '?' }
+                Quota   = if ($null -ne $quotaInfo.Available) { $quotaInfo.Available } else { '?' }
             }
 
             if ($FetchPricing) {

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A PowerShell tool for checking Azure VM SKU availability across regions - find w
 ![PowerShell](https://img.shields.io/badge/PowerShell-7.0%2B-blue)
 ![Azure](https://img.shields.io/badge/Azure-Az%20Modules-0078D4)
 ![License](https://img.shields.io/badge/License-MIT-green)
-![Version](https://img.shields.io/badge/Version-1.10.3-brightgreen)
+![Version](https://img.shields.io/badge/Version-1.10.4-brightgreen)
 
 ## Disclosure & Disclaimer
 
@@ -351,7 +351,7 @@ SKUs that are available but **incompatible** with your image are shown in dark y
 ### Console Output (with Pricing)
 ```
 ====================================================================================
-GET-AZVMAVAILABILITY v1.10.3
+GET-AZVMAVAILABILITY v1.10.4
 ====================================================================================
 SKU Filter: Standard_D2s_v5 | Pricing: Enabled
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-## Current Release: v1.10.3
+## Current Release: v1.10.4
 
 See [CHANGELOG.md](CHANGELOG.md) for full version history.
 


### PR DESCRIPTION
## Summary

Fixes the falsy-zero display bug discovered during Copilot PR review triage on #26.

## Problem

The family summary table used a truthiness check for quota display:
```powershell
Quota = if ($quotaInfo.Available) { $quotaInfo.Available } else { '?' }
```

In PowerShell, `if (0)` is falsy. So when v1.10.3 correctly returns `Available = 0` for GPU/HPC sub-families, the summary table displays `?` instead of `0`.

## Fix

Changed to explicit null check matching the per-SKU drill-down pattern:
```powershell
Quota = if ($null -ne $quotaInfo.Available) { $quotaInfo.Available } else { '?' }
```

## Additional

- Added Copilot PR review triage as step 3 in the release process guardrails skill

## Checklist

- [x] No subscription IDs, tenant IDs, or secrets in the PR
- [x] Changelog updated
- [x] Version bumped consistently (1.10.4)
- [x] Validate-Script.ps1 passes
