### PR TITLE
docs(roadmap): address Copilot review comments on AVD section

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -191,8 +191,6 @@ See [CHANGELOG.md](CHANGELOG.md) for full version history.
 
 ---
 
----
-
 ## Future: AVD Capacity Planning Mode
 **Theme: Azure Virtual Desktop Host Pool Sizing**
 
@@ -212,7 +210,7 @@ AVD deployments depend on VM SKU availability and quota (already covered), but a
 - Pooled host sizing math: `ceil(ConcurrentUsers / UsersPerVM)` with optional buffer percentage
 - Personal host sizing math: `1 VM per assigned user`
 - Spot placement scores (feature/placement-score-phase1) are directly relevant for cost-optimized pooled AVD
-- Plan session needed before implementation
+- AVD session planning decisions needed before implementation
 
 ---
 


### PR DESCRIPTION
## Summary

Addresses two Copilot review comments left on PR #29.

No functional changes — documentation only.

## Changes

- Remove duplicate --- horizontal rule before the AVD section header
- Rephrase awkward note: "Plan session needed before implementation" → "AVD session planning decisions needed before implementation"

## Related

Closes review feedback from #29
