### PR TITLE
chore(release): v1.11.1 -- Copilot skill for agent-driven VM availability scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.11.1] - 2026-03-12
+
 ### Added
 - Copilot skill (`.github/skills/azure-vm-availability/SKILL.md`) for AI agent integration -- teaches coding agents when and how to invoke Get-AzVMAvailability via terminal
 - README "AI Agent Integration" section with example agent invocations and installation instructions


### PR DESCRIPTION
## Summary

Promotes CHANGELOG \`[Unreleased]\` section to \`[1.11.1]\` with release date 2026-03-12.

This is a documentation-only change (no script logic modified).

## Changes
- CHANGELOG.md: \`[Unreleased]\` -> \`[1.11.1] - 2026-03-12\"

## Release Contents
- Copilot skill (\.github/skills/azure-vm-availability/SKILL.md\) for AI agent integration
- README "AI Agent Integration" section

## Checklist
- [x] CHANGELOG updated
- [x] No script changes (documentation only)
- [x] Tag v1.11.1 already pushed
