### PR TITLE
test: add coverage for 4 untested helper functions (142 to 182 tests)

### DIFF
--- a/Get-AzVMAvailability.ps1
+++ b/Get-AzVMAvailability.ps1
@@ -382,9 +382,10 @@ $script:RunContext = [pscustomobject]@{
     ShowPlacement      = $false
     DesiredCount       = 1
     Caches             = [ordered]@{
-        ValidRegions  = $null
-        Pricing       = @{}
-        ActualPricing = @{}
+        ValidRegions       = $null
+        Pricing            = @{}
+        ActualPricing      = @{}
+        PlacementWarned403 = $false
     }
 }
 $script:CachedValidRegions = $null

--- a/tests/HelperFunctions.Tests.ps1
+++ b/tests/HelperFunctions.Tests.ps1
@@ -12,12 +12,17 @@ BeforeAll {
         'Format-ZoneStatus',
         'Test-SkuMatchesFilter',
         'Get-SafeString',
-        'Get-GeoGroup'
+        'Get-GeoGroup',
+        'Get-QuotaAvailable',
+        'Get-SkuCapabilities'
     )
 
     foreach ($functionName in $functionNames) {
         . ([scriptblock]::Create((Get-MainScriptFunctionDefinition -FunctionName $functionName)))
     }
+
+    # Get-SkuCapabilities reads $MBPerGB from parent scope (known tech debt)
+    $script:MBPerGB = 1024
 }
 
 Describe "Get-SafeString" {
@@ -300,5 +305,167 @@ Describe "Get-GeoGroup" {
 
     It "Maps canadacentral to Americas-Canada" {
         Get-GeoGroup -LocationCode 'canadacentral' | Should -Be 'Americas-Canada'
+    }
+}
+
+Describe "Get-RestrictionReason" {
+
+    It "Returns null for SKU with no restrictions" {
+        $sku = [PSCustomObject]@{ Restrictions = @() }
+        Get-RestrictionReason -Sku $sku | Should -BeNullOrEmpty
+    }
+
+    It "Returns ReasonCode from a single restriction" {
+        $sku = [PSCustomObject]@{
+            Restrictions = @(
+                [PSCustomObject]@{ ReasonCode = 'Quota' }
+            )
+        }
+        Get-RestrictionReason -Sku $sku | Should -Be 'Quota'
+    }
+
+    It "Returns first ReasonCode when multiple restrictions exist" {
+        $sku = [PSCustomObject]@{
+            Restrictions = @(
+                [PSCustomObject]@{ ReasonCode = 'NotAvailableForSubscription' }
+                [PSCustomObject]@{ ReasonCode = 'Quota' }
+            )
+        }
+        Get-RestrictionReason -Sku $sku | Should -Be 'NotAvailableForSubscription'
+    }
+
+    It "Returns null for null Sku" {
+        Get-RestrictionReason -Sku $null | Should -BeNullOrEmpty
+    }
+}
+
+Describe "Get-QuotaAvailable" {
+
+    Context "Family not in quota lookup" {
+        It "Returns all nulls when family is missing" {
+            $result = Get-QuotaAvailable -QuotaLookup @{} -SkuFamily 'D'
+            $result.Available | Should -BeNullOrEmpty
+            $result.OK | Should -BeNullOrEmpty
+            $result.Limit | Should -BeNullOrEmpty
+            $result.Current | Should -BeNullOrEmpty
+        }
+    }
+
+    Context "Family found in quota lookup" {
+
+        BeforeAll {
+            $script:TestQuota = @{ 'D' = @{ Limit = 100; CurrentValue = 60 } }
+        }
+
+        It "Returns correct Available count (Limit - CurrentValue)" {
+            $result = Get-QuotaAvailable -QuotaLookup $script:TestQuota -SkuFamily 'D'
+            $result.Available | Should -Be 40
+            $result.Limit | Should -Be 100
+            $result.Current | Should -Be 60
+        }
+
+        It "OK is true when no RequiredvCPUs and available > 0" {
+            $result = Get-QuotaAvailable -QuotaLookup $script:TestQuota -SkuFamily 'D'
+            $result.OK | Should -BeTrue
+        }
+
+        It "OK is true when available meets RequiredvCPUs" {
+            $result = Get-QuotaAvailable -QuotaLookup $script:TestQuota -SkuFamily 'D' -RequiredvCPUs 32
+            $result.OK | Should -BeTrue
+        }
+
+        It "OK is false when available is below RequiredvCPUs" {
+            $result = Get-QuotaAvailable -QuotaLookup $script:TestQuota -SkuFamily 'D' -RequiredvCPUs 50
+            $result.OK | Should -BeFalse
+        }
+
+        It "OK is false when quota is fully exhausted" {
+            $fullQuota = @{ 'D' = @{ Limit = 100; CurrentValue = 100 } }
+            $result = Get-QuotaAvailable -QuotaLookup $fullQuota -SkuFamily 'D'
+            $result.OK | Should -BeFalse
+        }
+    }
+}
+
+Describe "Get-SkuCapabilities" {
+
+    Context "Defaults when no capabilities present" {
+        It "Returns HyperVGenerations V1 by default" {
+            $sku = [PSCustomObject]@{ Capabilities = @() }
+            (Get-SkuCapabilities -Sku $sku).HyperVGenerations | Should -Be 'V1'
+        }
+
+        It "Returns CpuArchitecture x64 by default" {
+            $sku = [PSCustomObject]@{ Capabilities = @() }
+            (Get-SkuCapabilities -Sku $sku).CpuArchitecture | Should -Be 'x64'
+        }
+
+        It "Returns TempDiskGB 0 by default" {
+            $sku = [PSCustomObject]@{ Capabilities = @() }
+            (Get-SkuCapabilities -Sku $sku).TempDiskGB | Should -Be 0
+        }
+
+        It "Returns NvmeSupport false by default" {
+            $sku = [PSCustomObject]@{ Capabilities = @() }
+            (Get-SkuCapabilities -Sku $sku).NvmeSupport | Should -BeFalse
+        }
+
+        It "Returns AcceleratedNetworkingEnabled false by default" {
+            $sku = [PSCustomObject]@{ Capabilities = @() }
+            (Get-SkuCapabilities -Sku $sku).AcceleratedNetworkingEnabled | Should -BeFalse
+        }
+    }
+
+    Context "Capability parsing" {
+        It "Parses HyperVGenerations V1,V2" {
+            $sku = [PSCustomObject]@{
+                Capabilities = @([PSCustomObject]@{ Name = 'HyperVGenerations'; Value = 'V1,V2' })
+            }
+            (Get-SkuCapabilities -Sku $sku).HyperVGenerations | Should -Be 'V1,V2'
+        }
+
+        It "Parses CpuArchitectureType = Arm64" {
+            $sku = [PSCustomObject]@{
+                Capabilities = @([PSCustomObject]@{ Name = 'CpuArchitectureType'; Value = 'Arm64' })
+            }
+            (Get-SkuCapabilities -Sku $sku).CpuArchitecture | Should -Be 'Arm64'
+        }
+
+        It "Converts MaxResourceVolumeMB to TempDiskGB (204800 MB = 200 GB)" {
+            $sku = [PSCustomObject]@{
+                Capabilities = @([PSCustomObject]@{ Name = 'MaxResourceVolumeMB'; Value = '204800' })
+            }
+            (Get-SkuCapabilities -Sku $sku).TempDiskGB | Should -Be 200
+        }
+
+        It "Sets AcceleratedNetworkingEnabled true from 'True' string" {
+            $sku = [PSCustomObject]@{
+                Capabilities = @([PSCustomObject]@{ Name = 'AcceleratedNetworkingEnabled'; Value = 'True' })
+            }
+            (Get-SkuCapabilities -Sku $sku).AcceleratedNetworkingEnabled | Should -BeTrue
+        }
+
+        It "Leaves AcceleratedNetworkingEnabled false from 'False' string" {
+            $sku = [PSCustomObject]@{
+                Capabilities = @([PSCustomObject]@{ Name = 'AcceleratedNetworkingEnabled'; Value = 'False' })
+            }
+            (Get-SkuCapabilities -Sku $sku).AcceleratedNetworkingEnabled | Should -BeFalse
+        }
+
+        It "Sets NvmeSupport true when NvmeDiskSizeInMiB is present" {
+            $sku = [PSCustomObject]@{
+                Capabilities = @([PSCustomObject]@{ Name = 'NvmeDiskSizeInMiB'; Value = '3686400' })
+            }
+            (Get-SkuCapabilities -Sku $sku).NvmeSupport | Should -BeTrue
+        }
+    }
+
+    Context "Null capabilities property" {
+        It "Returns defaults when Capabilities is null" {
+            $sku = [PSCustomObject]@{ Capabilities = $null }
+            $result = Get-SkuCapabilities -Sku $sku
+            $result.HyperVGenerations | Should -Be 'V1'
+            $result.CpuArchitecture | Should -Be 'x64'
+        }
     }
 }

--- a/tests/ImageCompatibility.Tests.ps1
+++ b/tests/ImageCompatibility.Tests.ps1
@@ -1,0 +1,150 @@
+# ImageCompatibility.Tests.ps1
+# Pester tests for Get-ImageRequirements and Test-ImageSkuCompatibility
+# Run with: Invoke-Pester .\tests\ImageCompatibility.Tests.ps1 -Output Detailed
+
+BeforeAll {
+    Import-Module "$PSScriptRoot\TestHarness.psm1" -Force
+    $functionNames = @(
+        'Get-ImageRequirements',
+        'Test-ImageSkuCompatibility'
+    )
+
+    foreach ($functionName in $functionNames) {
+        . ([scriptblock]::Create((Get-MainScriptFunctionDefinition -FunctionName $functionName)))
+    }
+}
+
+Describe "Get-ImageRequirements" {
+
+    Context "Valid URN parsing" {
+        It "Returns Valid=true with Gen1 and x64 for a standard URN" {
+            $result = Get-ImageRequirements -ImageURN 'Canonical:UbuntuServer:18.04-LTS:latest'
+            $result.Valid | Should -BeTrue
+            $result.Gen | Should -Be 'Gen1'
+            $result.Arch | Should -Be 'x64'
+        }
+
+        It "Parses publisher, offer, and sku from URN" {
+            $result = Get-ImageRequirements -ImageURN 'Canonical:UbuntuServer:18.04-LTS:latest'
+            $result.Publisher | Should -Be 'Canonical'
+            $result.Offer | Should -Be 'UbuntuServer'
+            $result.Sku | Should -Be '18.04-LTS'
+        }
+
+        It "Detects Gen2 from 'gen2' in SKU name" {
+            $result = Get-ImageRequirements -ImageURN 'Canonical:offer:20_04_lts-gen2:latest'
+            $result.Gen | Should -Be 'Gen2'
+        }
+
+        It "Detects Gen2 from '-g2' in SKU name" {
+            $result = Get-ImageRequirements -ImageURN 'Publisher:Offer:sku-g2:latest'
+            $result.Gen | Should -Be 'Gen2'
+        }
+
+        It "Detects Gen1 explicitly from 'gen1' in SKU name" {
+            $result = Get-ImageRequirements -ImageURN 'Publisher:Offer:sku-gen1:latest'
+            $result.Gen | Should -Be 'Gen1'
+        }
+
+        It "Detects ARM64 architecture and Gen2 from 'arm64' in SKU name" {
+            $result = Get-ImageRequirements -ImageURN 'Canonical:jammy:22_04-lts-arm64:latest'
+            $result.Arch | Should -Be 'ARM64'
+            $result.Gen | Should -Be 'Gen2'
+        }
+
+        It "Detects ARM64 architecture from 'aarch64' in SKU name" {
+            $result = Get-ImageRequirements -ImageURN 'Publisher:Offer:sku-aarch64:latest'
+            $result.Arch | Should -Be 'ARM64'
+        }
+    }
+
+    Context "Invalid URN format" {
+        It "Returns Valid=false for URN with fewer than 3 colon-separated parts (two-part)" {
+            $result = Get-ImageRequirements -ImageURN 'Canonical:UbuntuServer'
+            $result.Valid | Should -BeFalse
+            $result.Error | Should -Not -BeNullOrEmpty
+        }
+
+        It "Returns Valid=false for URN with no colons (single segment)" {
+            $result = Get-ImageRequirements -ImageURN 'JustAPublisher'
+            $result.Valid | Should -BeFalse
+        }
+    }
+}
+
+Describe "Test-ImageSkuCompatibility" {
+
+    Context "Fully compatible" {
+        It "Compatible when Gen1 image matches SKU that supports V1" {
+            $imageReqs = @{ Gen = 'Gen1'; Arch = 'x64' }
+            $caps = @{ HyperVGenerations = 'V1,V2'; CpuArchitecture = 'x64' }
+            $result = Test-ImageSkuCompatibility -ImageReqs $imageReqs -SkuCapabilities $caps
+            $result.Compatible | Should -BeTrue
+            $result.Reason | Should -Be 'OK'
+        }
+
+        It "Compatible when Gen2 image matches SKU that supports V2" {
+            $imageReqs = @{ Gen = 'Gen2'; Arch = 'x64' }
+            $caps = @{ HyperVGenerations = 'V1,V2'; CpuArchitecture = 'x64' }
+            $result = Test-ImageSkuCompatibility -ImageReqs $imageReqs -SkuCapabilities $caps
+            $result.Compatible | Should -BeTrue
+        }
+
+        It "Compatible when ARM64 image matches Arm64 SKU" {
+            $imageReqs = @{ Gen = 'Gen2'; Arch = 'ARM64' }
+            $caps = @{ HyperVGenerations = 'V2'; CpuArchitecture = 'Arm64' }
+            $result = Test-ImageSkuCompatibility -ImageReqs $imageReqs -SkuCapabilities $caps
+            $result.Compatible | Should -BeTrue
+        }
+    }
+
+    Context "Generation incompatible" {
+        It "Incompatible when Gen2 required but SKU only supports V1" {
+            $imageReqs = @{ Gen = 'Gen2'; Arch = 'x64' }
+            $caps = @{ HyperVGenerations = 'V1'; CpuArchitecture = 'x64' }
+            $result = Test-ImageSkuCompatibility -ImageReqs $imageReqs -SkuCapabilities $caps
+            $result.Compatible | Should -BeFalse
+            $result.Reason | Should -Match 'Gen2'
+        }
+
+        It "Incompatible when Gen1 required but SKU only supports V2" {
+            $imageReqs = @{ Gen = 'Gen1'; Arch = 'x64' }
+            $caps = @{ HyperVGenerations = 'V2'; CpuArchitecture = 'x64' }
+            $result = Test-ImageSkuCompatibility -ImageReqs $imageReqs -SkuCapabilities $caps
+            $result.Compatible | Should -BeFalse
+            $result.Reason | Should -Match 'Gen1'
+        }
+    }
+
+    Context "Architecture incompatible" {
+        It "Incompatible when ARM64 required but SKU is x64" {
+            $imageReqs = @{ Gen = 'Gen2'; Arch = 'ARM64' }
+            $caps = @{ HyperVGenerations = 'V1,V2'; CpuArchitecture = 'x64' }
+            $result = Test-ImageSkuCompatibility -ImageReqs $imageReqs -SkuCapabilities $caps
+            $result.Compatible | Should -BeFalse
+            $result.Reason | Should -Match 'ARM64'
+        }
+
+        It "Incompatible when x64 required but SKU is Arm64" {
+            $imageReqs = @{ Gen = 'Gen1'; Arch = 'x64' }
+            $caps = @{ HyperVGenerations = 'V2'; CpuArchitecture = 'Arm64' }
+            $result = Test-ImageSkuCompatibility -ImageReqs $imageReqs -SkuCapabilities $caps
+            $result.Compatible | Should -BeFalse
+            $result.Reason | Should -Match 'x64'
+        }
+    }
+
+    Context "Output fields" {
+        It "Gen field shows numeric generations without V prefix (V1,V2 → 1,2)" {
+            $imageReqs = @{ Gen = 'Gen1'; Arch = 'x64' }
+            $caps = @{ HyperVGenerations = 'V1,V2'; CpuArchitecture = 'x64' }
+            (Test-ImageSkuCompatibility -ImageReqs $imageReqs -SkuCapabilities $caps).Gen | Should -Be '1,2'
+        }
+
+        It "Arch field returns the SKU's CpuArchitecture value" {
+            $imageReqs = @{ Gen = 'Gen2'; Arch = 'ARM64' }
+            $caps = @{ HyperVGenerations = 'V2'; CpuArchitecture = 'Arm64' }
+            (Test-ImageSkuCompatibility -ImageReqs $imageReqs -SkuCapabilities $caps).Arch | Should -Be 'Arm64'
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Tests audit: identified 12 functions with no coverage. Added tests for the 4 highest-priority gaps, bringing the suite from 142 to 182 tests (+40).

## Changes

### tests/HelperFunctions.Tests.ps1
- Added Get-QuotaAvailable and Get-SkuCapabilities to the BeforeAll function load list
- Added ` = 1024` to BeforeAll (resolves Get-SkuCapabilities parent-scope dependency)
- Added Describe "Get-RestrictionReason" (was loaded in BeforeAll but had no test block)
- Added Describe "Get-QuotaAvailable" - quota math, used in every scan row
- Added Describe "Get-SkuCapabilities" - capability parsing for fleet safety and recommend engine

### tests/ImageCompatibility.Tests.ps1 (new file)
- Describe "Get-ImageRequirements" - URN parsing, gen/arch detection, invalid format handling
- Describe "Test-ImageSkuCompatibility" - generation/architecture compatibility gating, output field format

### Get-AzVMAvailability.ps1
- Added PlacementWarned403 = false to RunContext.Caches initializer so the key is explicitly declared at startup rather than lazily on first 403 catch

## Test Run
Tests Passed: 182, Failed: 0, Skipped: 0
