### PR TITLE
fix: address Copilot post-merge comments on PR #24

### DIFF
--- a/.github/skills/release-verification-checklist/SKILL.md
+++ b/.github/skills/release-verification-checklist/SKILL.md
@@ -32,9 +32,10 @@ description: Verify local script release readiness against upstream main (versio
 - Guard check: `Select-String -Path .\Get-AzVMAvailability.ps1 -Pattern 'AzureEndpoints\s*=\s*\$null|Add-Member.+AzureEndpoints|RunContext\.AzureEndpoints'`
 - Upstream hash compare:
   - `$u = "https://raw.githubusercontent.com/ZacharyLuz/Get-AzVMAvailability/main/Get-AzVMAvailability.ps1"`
-  - `Invoke-WebRequest -Uri $u -OutFile "$env:TEMP\Get-AzVMAvailability.main.ps1"`
+  - `$tmp = [System.IO.Path]::GetTempPath(); $remote = Join-Path -Path $tmp -ChildPath 'Get-AzVMAvailability.main.ps1'`
+  - `Invoke-WebRequest -Uri $u -OutFile $remote`
   - `(Get-FileHash .\Get-AzVMAvailability.ps1).Hash`
-  - `(Get-FileHash "$env:TEMP\Get-AzVMAvailability.main.ps1").Hash`
+  - `(Get-FileHash $remote).Hash`
 - Smoke run: `pwsh -File .\Get-AzVMAvailability.ps1 -NoPrompt -Region eastus -FamilyFilter D -TopN 3`
 
 ## Notes

--- a/.github/workflows/release-metadata-guard.yml
+++ b/.github/workflows/release-metadata-guard.yml
@@ -32,7 +32,7 @@ jobs:
             throw "Required closeout checklist skill missing: .github/skills/release-verification-checklist/SKILL.md"
           }
 
-          git fetch origin "${{ github.base_ref }}" --depth=1
+          git fetch origin "${{ github.base_ref || 'main' }}" --depth=1
 
           $headScript = Get-Content "./Get-AzVMAvailability.ps1" -Raw
           $headMatch = [regex]::Match($headScript, '(?m)^\$ScriptVersion\s*=\s*"([^"]+)"')
@@ -41,7 +41,7 @@ jobs:
           }
           $headVersion = $headMatch.Groups[1].Value
 
-          $baseScript = (git show "origin/${{ github.base_ref }}:Get-AzVMAvailability.ps1") -join "`n"
+          $baseScript = (git show "origin/${{ github.base_ref || 'main' }}:Get-AzVMAvailability.ps1") -join "`n"
           $baseMatch = [regex]::Match($baseScript, '(?m)^\$ScriptVersion\s*=\s*"([^"]+)"')
           if (-not $baseMatch.Success) {
             throw "Could not read ScriptVersion from base branch script."

--- a/.github/workflows/release-on-main.yml
+++ b/.github/workflows/release-on-main.yml
@@ -92,7 +92,7 @@ jobs:
           $version = "${{ steps.drift.outputs.version }}"
           $title = "Release metadata drift detected: $tag"
           $body = @(
-            "Script version is \\$ScriptVersion = $version on \\`main\\`, but tag/release $tag does not exist."
+            "Script version is \`$ScriptVersion = $version on \\`main\\`, but tag/release $tag does not exist."
             ""
             "Required action:"
             "1. Create tag $tag on the merge commit."

--- a/docs/VERIFY-RELEASE.md
+++ b/docs/VERIFY-RELEASE.md
@@ -44,10 +44,12 @@ Expected: at least one hit for the run-context property initialization and assig
 ## 5) Detect Stale Local Copy (Hash Compare with Upstream main)
 
 ```powershell
-$u = "https://raw.githubusercontent.com/ZacharyLuz/Get-AzVMAvailability/main/Get-AzVMAvailability.ps1"
-Invoke-WebRequest -Uri $u -OutFile "$env:TEMP\Get-AzVMAvailability.main.ps1"
+$u       = "https://raw.githubusercontent.com/ZacharyLuz/Get-AzVMAvailability/main/Get-AzVMAvailability.ps1"
+$tempDir = [System.IO.Path]::GetTempPath()
+$outFile = Join-Path -Path $tempDir -ChildPath "Get-AzVMAvailability.main.ps1"
+Invoke-WebRequest -Uri $u -OutFile $outFile
 (Get-FileHash .\Get-AzVMAvailability.ps1).Hash
-(Get-FileHash "$env:TEMP\Get-AzVMAvailability.main.ps1").Hash
+(Get-FileHash $outFile).Hash
 ```
 
 Expected: hashes are identical.


### PR DESCRIPTION
## Summary

Addresses 4 Copilot review comments posted on PR #24 after merge.

## Changes

- **Cross-platform temp path** (`docs/VERIFY-RELEASE.md`, `.github/skills/release-verification-checklist/SKILL.md`): Replace `\\C:\Users\zaluz\AppData\Local\Temp\` with `[System.IO.Path]::GetTempPath()` + `Join-Path` so hash-compare commands work on Linux/Cloud Shell where `$env:TEMP` may be unset.

- **`$ScriptVersion` variable expansion** (`.github/workflows/release-on-main.yml`): Backtick-escape `$ScriptVersion` so the literal variable name appears in the opened GitHub issue instead of expanding to an empty string.

- **`workflow_dispatch` / `github.base_ref`** (`.github/workflows/release-metadata-guard.yml`): Add `|| 'main'` fallback so manual dispatch runs don't fail with empty `base_ref` on both `git fetch` and `git show`.

## Checklist

- [x] Changes are limited to the files described
- [x] No test changes required (docs/workflow YAML only)
