### PR TITLE
fix: aarch64 Gen2 detection + test log redirect (Copilot triage PR #35-39)

### DIFF
--- a/Get-AzVMAvailability.ps1
+++ b/Get-AzVMAvailability.ps1
@@ -1762,7 +1762,7 @@ function Get-ImageRequirements {
 
     # Determine Generation from SKU name patterns
     $gen = 'Gen1'  # Default to Gen1 for compatibility
-    if ($sku -match '-gen2|-g2|gen2|_gen2|arm64') {
+    if ($sku -match '-gen2|-g2|gen2|_gen2|arm64|aarch64') {
         $gen = 'Gen2'
     }
     elseif ($sku -match '-gen1|-g1|gen1|_gen1') {

--- a/tests/ImageCompatibility.Tests.ps1
+++ b/tests/ImageCompatibility.Tests.ps1
@@ -1,6 +1,6 @@
 # ImageCompatibility.Tests.ps1
 # Pester tests for Get-ImageRequirements and Test-ImageSkuCompatibility
-# Run with: Invoke-Pester .\tests\ImageCompatibility.Tests.ps1 -Output Detailed
+# Run with: Invoke-Pester .\tests\ImageCompatibility.Tests.ps1 -Output Detailed *> artifacts/test-run.log
 
 BeforeAll {
     Import-Module "$PSScriptRoot\TestHarness.psm1" -Force
@@ -55,6 +55,7 @@ Describe "Get-ImageRequirements" {
         It "Detects ARM64 architecture from 'aarch64' in SKU name" {
             $result = Get-ImageRequirements -ImageURN 'Publisher:Offer:sku-aarch64:latest'
             $result.Arch | Should -Be 'ARM64'
+            $result.Gen | Should -Be 'Gen2'
         }
     }
 


### PR DESCRIPTION
## Summary

Addresses 2 Copilot review findings from PRs #38 (image compatibility test coverage) and #35 (aarch64 Gen detection). 8 other findings from PRs #35–#39 triaged as Disagree (full log in `artifacts/copilot-review-log.md`).

## Changes

- **`Get-ImageRequirements` Gen2 detection** (`Get-AzVMAvailability.ps1`): Add `aarch64` to the Gen2 regex pattern alongside `arm64`. Azure Ampere ARM64 VMs always require Gen2 UEFI boot — `aarch64`-named SKUs were correctly getting `Arch=ARM64` but incorrectly staying `Gen=Gen1`, causing potential false-pass in image compatibility checks (`arm64` already triggered Gen2; `aarch64` did not).

- **`aarch64` test assertion** (`tests/ImageCompatibility.Tests.ps1`): Add `$result.Gen | Should -Be 'Gen2'` to the existing `aarch64` test to lock in the corrected behavior.

- **Test header run command** (`tests/ImageCompatibility.Tests.ps1`): Add `*> artifacts/test-run.log` to the `# Run with:` header comment — consistent with pester-log-first-validation-pattern and other test files.

## Copilot Triage Summary (PRs #35–#39)

| PR | Finding | File | Assessment |
|----|---------|------|------------|
| #35 | Skill version "1.1.0" typo | SKILL.md:7 | Disagree — intentional skill semver, explicitly commented |
| #35 | JSON schema missing fields | SKILL.md:328 | Disagree — Note block documents brevity intentionally |
| #35 | ~/.agents/skills/ discovery | README.md:433 | Disagree — user's real personal skill system, not a VS Code claim |
| #35 | CHANGELOG entry missing | README.md:411 | Disagree — entry exists at CHANGELOG.md:27 (1.11.1 section) |
| #36 | Tag before merge | CHANGELOG.md:14 | Partially Agree — historical violation, no retroactive fix possible |
| #37 | Windows path separator | Validate-Script.ps1:64 | Disagree — `GetRelativePath()` already in code; Copilot saw old version |
| #38 | MBPerGB hardcoded | HelperFunctions.Tests.ps1:25 | Disagree — intentional tech-debt workaround, documented in comments |
| #38 | Test header log redirect | ImageCompatibility.Tests.ps1:3 | **Agree — fixed** |
| #38 | aarch64 Gen1 inconsistency | ImageCompatibility.Tests.ps1:57 | **Agree — fixed** |
| #39 | null string dedup bug | scheduled-health-check.yml:54 | Disagree — `// empty` already in code; Copilot saw old version |

## Checklist

- [x] Changes are limited to the files described
- [x] Syntax validated (`[scriptblock]::Create()` PASS)
- [x] No version bump required (test and gen-detection bug fix only)
