### PR TITLE
fix: sync .NOTES Version with ScriptVersion, add CI parity guard

### DIFF
--- a/.github/workflows/release-metadata-guard.yml
+++ b/.github/workflows/release-metadata-guard.yml
@@ -48,6 +48,18 @@ jobs:
           }
           $baseVersion = $baseMatch.Groups[1].Value
 
+          # Verify .NOTES Version matches $ScriptVersion
+          $notesMatch = [regex]::Match($headScript, '(?m)\.NOTES[\s\S]*?Version:\s*([\d.]+)')
+          if ($notesMatch.Success) {
+            $notesVersion = $notesMatch.Groups[1].Value
+            if ($notesVersion -ne $headVersion) {
+              throw ".NOTES Version ($notesVersion) does not match `$ScriptVersion ($headVersion). Both must be identical."
+            }
+            Write-Host ".NOTES Version matches ScriptVersion: $headVersion"
+          } else {
+            throw "Could not find Version in .NOTES comment block."
+          }
+
           Write-Host "Base version: $baseVersion"
           Write-Host "Head version: $headVersion"
 

--- a/Get-AzVMAvailability.ps1
+++ b/Get-AzVMAvailability.ps1
@@ -126,7 +126,7 @@
     Author:         Zachary Luz
     Company:        Microsoft
     Created:        2026-01-21
-    Version:        1.11.0
+    Version:        1.11.2
     License:        MIT
     Repository:     https://github.com/zacharyluz/Get-AzVMAvailability
 


### PR DESCRIPTION
## Summary

Fixes .NOTES Version metadata drift from $ScriptVersion and adds a CI guard to prevent recurrence.

## Changes

1. **Get-AzVMAvailability.ps1** — .NOTES Version synced from 1.11.0 to 1.11.2 (matches $ScriptVersion)
2. **release-metadata-guard.yml** — Added .NOTES vs $ScriptVersion parity check that fails the PR if they diverge

## Root Cause

The v1.11.2 commit bumped $ScriptVersion but missed the .NOTES comment block. The local Validate-Script.ps1 already had this check, but the CI workflow (elease-metadata-guard.yml) only compared $ScriptVersion between PR head and base — it never read .NOTES.

## Testing

- [x] No functional changes — metadata fix only
- [ ] Release/tag plan prepared for this version bump

## Checklist

- [x] CHANGELOG not required (no version bump, metadata fix for existing version)
- [x] CI guard will self-validate on this PR
