### PR TITLE
fix: changelog [Unreleased] guard regex allowed empty sections to pass CI

### DIFF
--- a/.github/workflows/release-metadata-guard.yml
+++ b/.github/workflows/release-metadata-guard.yml
@@ -78,8 +78,10 @@ jobs:
             Write-Host "CHANGELOG heading ## [$headVersion] found."
           } else {
             Write-Host "ScriptVersion unchanged ($headVersion). Verifying [Unreleased] section has content..."
-            # Capture everything between ## [Unreleased] and the next ## [ heading
-            $unreleasedMatch = [regex]::Match($changelog, '(?s)##\s+\[Unreleased\]\s*(.*?)(?=\r?\n##\s+\[|\z)')
+            # Capture content between ## [Unreleased] heading and the next ## [ heading
+            # Uses [^\n]* (not \s*) after heading to avoid consuming newlines that
+            # belong to the boundary, which would let the lazy (.*?) skip past ## [x.y.z]
+            $unreleasedMatch = [regex]::Match($changelog, '(?s)##\s+\[Unreleased\][^\n]*\n(.*?)(?=\n##\s+\[|\z)')
             if (-not $unreleasedMatch.Success) {
               throw "CHANGELOG.md is missing ## [Unreleased] section."
             }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- CI: Fixed `[Unreleased]` changelog guard regex that allowed empty sections to pass — `\s*` consumed newlines past the heading boundary, causing `(.*?)` to capture the next version's content instead of detecting an empty section
+
 ## [1.11.2] - 2026-03-12
 
 ### Added


### PR DESCRIPTION
## Summary

Fixes a regex bug in `release-metadata-guard.yml` where an empty `## [Unreleased]` section passed CI validation instead of failing.

## Root Cause

The regex `(?s)##\s+\[Unreleased\]\s*(.*?)(?=\r?\n##\s+\[|\z)` used `\s*` after the heading, which consumed the newlines between `## [Unreleased]` and `## [1.11.2]`. This caused the lazy `(.*?)` to start capturing at the `## [1.11.2]` heading — so the captured group contained the entire next version's content instead of being empty.

**Old:** `\s*` ate newlines past the boundary → content from `[1.11.2]` leaked into the capture → `IsNullOrWhiteSpace` returned `$false` → CI passed

**Fixed:** `[^\n]*\n` consumes only the rest of the heading line, then `(.*?)` correctly captures only between `[Unreleased]` and the next `## [` → empty section returns empty string → CI fails as intended

## Testing

Validated locally with both cases:
- Empty `[Unreleased]`: `len=0, empty=True` (now correctly fails)
- `[Unreleased]` with entries: `len=21, body=[- Added something new]` (still passes)

## Copilot Review Origin

This bug was surfaced by Copilot's review comment on PR #44 (assessed as "Partially Agree" — finding was correct, but CI had passed empirically due to this regex edge case).

## Checklist

- [x] CHANGELOG [Unreleased] entry added
- [ ] Release/tag plan prepared for this version bump
