### PR TITLE
feat: Fleet MVP — -Fleet BOM readiness validation with P0 fixes

### DIFF
--- a/.github/workflows/release-on-main.yml
+++ b/.github/workflows/release-on-main.yml
@@ -125,7 +125,7 @@ jobs:
 
           throw "Release metadata drift detected for $tag and auto-publish is disabled."
 
-      - name: Auto-publish draft release when drift detected
+      - name: Auto-publish release when drift detected
         if: steps.drift.outputs.tag_exists == 'False' && (github.event_name == 'push' || inputs.auto_publish == true)
         env:
           GH_TOKEN: ${{ github.token }}
@@ -145,7 +145,10 @@ jobs:
           git tag "$tag" "$sha"
           git push origin "$tag"
 
-          $draft = $true
+          # Default to published (not draft) — release notes are editable on GitHub
+          # without a new PR. Draft releases required fix-CHANGELOG → PR → merge → publish
+          # cycle for every typo. Manual dispatch can still override via draft_release input.
+          $draft = $false
           if ("${{ github.event_name }}" -eq "workflow_dispatch") {
             $draft = "${{ inputs.draft_release }}" -eq "true"
           }

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ copilot-standing-rules.md
 # Temp files
 *.tmp
 *.temp
+.tmp_*  # dotfile-prefixed temp files (.tmp_reply.json, .tmp_pr_body.md) — complements *.tmp pattern above
 *.out
 *~
 *.swp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Fleet Readiness Mode** — `-Fleet` hashtable parameter for BOM-level capacity and quota validation (`-Fleet @{'Standard_D2s_v5'=17; 'Standard_D4s_v5'=4}`)
+- Fleet auto-derives `-SkuFilter` from Fleet keys with double-prefix guard (`Standard_Standard_` → `Standard_`)
+- `Get-FleetReadiness` function — validates fleet BOM against scan data, checks per-SKU capacity, aggregates vCPU demand per quota family with fuzzy family name matching fallback
+- `Write-FleetReadinessSummary` function — color-coded console output with per-SKU table, per-family quota pass/fail (Used/Available/Limit), and overall verdict
+
+### Changed
+- Release workflow: push-to-main releases now auto-publish (not draft) — release notes are editable on GitHub without a new PR; manual dispatch still defaults to draft via `draft_release` input
+
 ### Fixed
 - Tooling: `Validate-Script.ps1` Check 5 docs scan now uses `git ls-files` instead of `Get-ChildItem` so only committed/staged files can trigger version-consistency failures — prevents false positives from local untracked scratch notes under `docs/`
 - Tooling: `Validate-Script.ps1` Check 5 now guards `git ls-files` with `Get-Command git` — falls back to `Get-ChildItem` with a `WARN` when git is unavailable (e.g. source ZIP install), preventing a `CommandNotFoundException` crash

--- a/Get-AzVMAvailability.ps1
+++ b/Get-AzVMAvailability.ps1
@@ -309,7 +309,10 @@ param(
     [switch]$AllowMixedArch,
 
     [Parameter(Mandatory = $false, HelpMessage = "Skip validation of region names against Azure metadata")]
-    [switch]$SkipRegionValidation
+    [switch]$SkipRegionValidation,
+
+    [Parameter(Mandatory = $false, HelpMessage = "Fleet BOM: hashtable of SKU=Quantity pairs for fleet readiness validation (e.g., @{'Standard_D2s_v5'=17; 'Standard_D4s_v5'=4})")]
+    [hashtable]$Fleet
 )
 
 $ProgressPreference = 'SilentlyContinue'  # Suppress progress bars for faster execution
@@ -327,6 +330,19 @@ foreach ($paramName in @('SubscriptionId', 'Region', 'FamilyFilter', 'SkuFilter'
     if ($val -and $val.Count -eq 1 -and $val[0] -match ',') {
         Set-Variable -Name $paramName -Value @($val[0] -split ',' | ForEach-Object { $_.Trim().Trim('"', "'") } | Where-Object { $_ })
     }
+}
+
+# Fleet mode: normalize keys (strip double-prefix) and derive SkuFilter
+if ($Fleet -and $Fleet.Count -gt 0) {
+    $normalizedFleet = @{}
+    foreach ($key in @($Fleet.Keys)) {
+        $clean = $key -replace '^Standard_Standard_', 'Standard_'
+        if ($clean -notmatch '^Standard_') { $clean = "Standard_$clean" }
+        $normalizedFleet[$clean] = $Fleet[$key]
+    }
+    $Fleet = $normalizedFleet
+    $SkuFilter = @($Fleet.Keys)
+    Write-Verbose "Fleet mode: derived SkuFilter from $($Fleet.Count) Fleet SKUs"
 }
 
 #region Configuration
@@ -1012,6 +1028,222 @@ function Get-QuotaAvailable {
         Limit     = $quota.Limit
         Current   = $quota.CurrentValue
     }
+}
+
+function Get-FleetReadiness {
+    <#
+    .SYNOPSIS
+        Validates a fleet BOM against scan data to produce per-SKU and per-quota-family readiness.
+    .DESCRIPTION
+        Takes a Fleet hashtable (SKU=Qty) and scan data, then checks:
+        1. Does each SKU exist in the scanned regions?
+        2. What is the capacity status for each SKU?
+        3. Does the quota family have enough available vCPUs for the aggregated demand?
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [hashtable]$Fleet,
+
+        [Parameter(Mandatory)]
+        [array]$SubscriptionData
+    )
+
+    $results = [System.Collections.Generic.List[PSCustomObject]]::new()
+    $quotaDemandByFamily = @{}
+
+    foreach ($skuName in $Fleet.Keys) {
+        $normalizedSku = $skuName
+        $qty = [int]$Fleet[$skuName]
+
+        $foundInAnyRegion = $false
+        $bestStatus = 'NOT FOUND'
+        $bestRegion = $null
+        $skuVcpu = 0
+        $skuFamily = $null
+        $skuMemGiB = 0
+        $quotaAvailable = $null
+        $quotaLimit = $null
+        $quotaCurrent = $null
+
+        foreach ($subData in $SubscriptionData) {
+            foreach ($regionData in $subData.RegionData) {
+                if ($regionData.Error) { continue }
+                $region = Get-SafeString $regionData.Region
+
+                foreach ($sku in $regionData.Skus) {
+                    if ($sku.Name -ne $normalizedSku) { continue }
+                    $foundInAnyRegion = $true
+                    $skuVcpu = [int](Get-CapValue $sku 'vCPUs')
+                    $skuMemGiB = [int](Get-CapValue $sku 'MemoryGB')
+                    $skuFamily = $sku.Family
+
+                    $restrictions = Get-RestrictionDetails $sku
+                    $status = $restrictions.Status
+
+                    # Rank: OK > LIMITED > CAPACITY-CONSTRAINED > RESTRICTED > BLOCKED
+                    $statusRank = switch ($status) {
+                        'OK' { 5 }
+                        'LIMITED' { 4 }
+                        'CAPACITY-CONSTRAINED' { 3 }
+                        'PARTIAL' { 2 }
+                        'RESTRICTED' { 1 }
+                        default { 0 }
+                    }
+                    $bestRank = switch ($bestStatus) {
+                        'OK' { 5 }
+                        'LIMITED' { 4 }
+                        'CAPACITY-CONSTRAINED' { 3 }
+                        'PARTIAL' { 2 }
+                        'RESTRICTED' { 1 }
+                        'NOT FOUND' { -1 }
+                        default { 0 }
+                    }
+
+                    if ($statusRank -gt $bestRank) {
+                        $bestStatus = $status
+                        $bestRegion = $region
+                    }
+
+                    # Build quota lookup for this region
+                    $quotaLookup = @{}
+                    foreach ($q in $regionData.Quotas) { $quotaLookup[$q.Name.Value] = $q }
+
+                    # Try exact match first, then substring fallback
+                    $matchedFamily = $skuFamily
+                    if ($skuFamily -and -not $quotaLookup[$skuFamily]) {
+                        $fallback = $quotaLookup.Keys | Where-Object { $skuFamily -like "*$_*" -or $_ -like "*$skuFamily*" } | Select-Object -First 1
+                        if ($fallback) { $matchedFamily = $fallback }
+                    }
+
+                    if ($matchedFamily -and $quotaLookup[$matchedFamily]) {
+                        $qInfo = Get-QuotaAvailable -QuotaLookup $quotaLookup -SkuFamily $matchedFamily
+                        $quotaAvailable = $qInfo.Available
+                        $quotaLimit = $qInfo.Limit
+                        $quotaCurrent = $qInfo.Current
+                    }
+                }
+            }
+        }
+
+        $totalVcpuDemand = $qty * $skuVcpu
+
+        # Aggregate demand per quota family for cross-SKU quota check
+        if ($skuFamily) {
+            if (-not $quotaDemandByFamily.ContainsKey($skuFamily)) {
+                $quotaDemandByFamily[$skuFamily] = @{ Demand = 0; Available = $quotaAvailable; Limit = $quotaLimit; Current = $quotaCurrent }
+            }
+            $quotaDemandByFamily[$skuFamily].Demand += $totalVcpuDemand
+        }
+
+        $results.Add([pscustomobject]@{
+            SKU           = $normalizedSku
+            Qty           = $qty
+            vCPUEach      = $skuVcpu
+            MemGiBEach    = $skuMemGiB
+            TotalvCPU     = $totalVcpuDemand
+            QuotaFamily   = if ($skuFamily) { $skuFamily } else { '?' }
+            Capacity      = $bestStatus
+            BestRegion    = if ($bestRegion) { $bestRegion } else { '-' }
+            QuotaUsed     = if ($null -ne $quotaCurrent) { $quotaCurrent } else { '?' }
+            QuotaAvail    = if ($null -ne $quotaAvailable) { $quotaAvailable } else { '?' }
+            QuotaLimit    = if ($null -ne $quotaLimit) { $quotaLimit } else { '?' }
+            Found         = $foundInAnyRegion
+        })
+    }
+
+    # Compute per-family quota pass/fail
+    $familyResults = [System.Collections.Generic.List[PSCustomObject]]::new()
+    foreach ($family in $quotaDemandByFamily.Keys) {
+        $entry = $quotaDemandByFamily[$family]
+        $pass = if ($null -ne $entry.Available) { $entry.Available -ge $entry.Demand } else { $null }
+        $familyResults.Add([pscustomobject]@{
+            QuotaFamily   = $family
+            TotalDemand   = $entry.Demand
+            Used          = if ($null -ne $entry.Current) { $entry.Current } else { '?' }
+            Available     = if ($null -ne $entry.Available) { $entry.Available } else { '?' }
+            Limit         = if ($null -ne $entry.Limit) { $entry.Limit } else { '?' }
+            Pass          = $pass
+        })
+    }
+
+    return @{
+        SKUs    = @($results)
+        Quotas  = @($familyResults)
+    }
+}
+
+function Write-FleetReadinessSummary {
+    <#
+    .SYNOPSIS
+        Renders the fleet readiness summary to console with color-coded pass/fail.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [hashtable]$FleetResult,
+
+        [Parameter(Mandatory)]
+        [hashtable]$Fleet
+    )
+
+    $totalVMs = ($Fleet.Values | Measure-Object -Sum).Sum
+    $totalvCPU = ($FleetResult.SKUs | Measure-Object -Property TotalvCPU -Sum).Sum
+
+    Write-Host ""
+    Write-Host ("=" * 100) -ForegroundColor Gray
+    Write-Host "FLEET READINESS SUMMARY" -ForegroundColor Cyan
+    Write-Host ("=" * 100) -ForegroundColor Gray
+    Write-Host "Fleet: $($Fleet.Count) SKUs | $totalVMs VMs | $totalvCPU vCPUs total" -ForegroundColor White
+    Write-Host ""
+
+    # Per-SKU table
+    $headerFmt = "{0,-28} {1,4} {2,5} {3,5} {4,10} {5,22} {6,-12}"
+    Write-Host ($headerFmt -f 'SKU', 'Qty', 'vCPU', 'Mem', 'Need', 'Capacity', 'Region') -ForegroundColor White
+    Write-Host ("-" * 100) -ForegroundColor Gray
+
+    foreach ($row in $FleetResult.SKUs) {
+        $capacityColor = switch ($row.Capacity) {
+            'OK'                    { 'Green' }
+            'LIMITED'               { 'Yellow' }
+            'CAPACITY-CONSTRAINED'  { 'DarkYellow' }
+            'NOT FOUND'             { 'Red' }
+            default                 { 'Gray' }
+        }
+        $needStr = "$($row.TotalvCPU) vCPU"
+        $line = $headerFmt -f $row.SKU, $row.Qty, $row.vCPUEach, $row.MemGiBEach, $needStr, $row.Capacity, $row.BestRegion
+        Write-Host $line -ForegroundColor $capacityColor
+    }
+
+    Write-Host ""
+    Write-Host "QUOTA VALIDATION BY FAMILY:" -ForegroundColor White
+    Write-Host ("-" * 100) -ForegroundColor Gray
+
+    $quotaFmt = "{0,-40} {1,8} {2,8} {3,10} {4,8} {5,6}"
+    Write-Host ($quotaFmt -f 'Quota Family', 'Need', 'Used', 'Available', 'Limit', 'Pass') -ForegroundColor White
+    Write-Host ("-" * 100) -ForegroundColor Gray
+
+    $allPass = $true
+    foreach ($q in $FleetResult.Quotas) {
+        $passStr = if ($null -eq $q.Pass) { '?' } elseif ($q.Pass) { 'YES' } else { 'NO' }
+        $passColor = if ($null -eq $q.Pass) { 'Yellow' } elseif ($q.Pass) { 'Green' } else { 'Red' }
+        if ($q.Pass -eq $false) { $allPass = $false }
+        if ($null -eq $q.Pass) { $allPass = $false }
+
+        $line = $quotaFmt -f $q.QuotaFamily, $q.TotalDemand, $q.Used, $q.Available, $q.Limit, $passStr
+        Write-Host $line -ForegroundColor $passColor
+    }
+
+    Write-Host ""
+    if ($allPass) {
+        Write-Host "FLEET READINESS: PASS" -ForegroundColor Green -BackgroundColor Black
+        Write-Host "All SKUs have capacity and quota covers the fleet demand." -ForegroundColor Green
+    }
+    else {
+        Write-Host "FLEET READINESS: FAIL" -ForegroundColor Red -BackgroundColor Black
+        Write-Host "One or more SKUs have capacity issues or insufficient quota." -ForegroundColor Red
+        Write-Host "Request quota increase: https://aka.ms/ProdportalCRP/?#create/Microsoft.Support/Parameters/" -ForegroundColor Yellow
+    }
+
+    Write-Host ("=" * 100) -ForegroundColor Gray
 }
 
 function Get-StatusIcon {
@@ -2909,6 +3141,21 @@ catch {
 }
 
 #endregion Data Collection
+#region Fleet Readiness
+
+if ($Fleet -and $Fleet.Count -gt 0) {
+    $fleetResult = Get-FleetReadiness -Fleet $Fleet -SubscriptionData $allSubscriptionData
+    Write-FleetReadinessSummary -FleetResult $fleetResult -Fleet $Fleet
+
+    if ($JsonOutput) {
+        $fleetResult | ConvertTo-Json -Depth 5
+    }
+
+    # Fleet mode exits after summary — no need to render full scan output
+    return
+}
+
+#endregion Fleet Readiness
 #region Recommend Mode
 
 if ($Recommend) {

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -198,6 +198,8 @@ See [CHANGELOG.md](CHANGELOG.md) for full version history.
 - [ ] **Workload Profiles** - Pre-tuned scoring weights for MemoryOptimized, ComputeOptimized, GPU
 - [ ] **VMSS Script Generation** - Generate deployment scripts for regional fleet allocation
 - [ ] **Fleet Strategy Modes** - Balanced/HighAvailability/CostOptimized/MaxSavings
+- [ ] **Azure Compute Fleet Integration** - Evaluate `Microsoft.AzureFleet/fleets` API for mixed Spot+on-demand fleet deployments (requires `Compute Fleet Contributor` role `2bed379c`) <!-- short GUID is intentional — roadmap reference, not RBAC assignment code -->
+- [ ] **Programmatic Quota Management** - Evaluate `Microsoft.ComputeLimit` API for automated quota increase requests (requires `Compute Limit Operator` role `980cf6f7`) <!-- short GUID is intentional — roadmap reference, not RBAC assignment code -->
 
 ---
 
@@ -286,6 +288,49 @@ AVD deployments depend on VM SKU availability and quota (already covered), but a
 - Personal host sizing math: `1 VM per assigned user`
 - Spot placement scores (feature/placement-score-phase1) are directly relevant for cost-optimized pooled AVD
 - AVD session planning decisions needed before implementation
+
+---
+
+## Future: SKU Modernization Scanner
+**Theme: Proactive SKU Retirement & Capacity Risk Detection**
+
+Scan a subscription's deployed VMs to find SKUs that are scheduled for retirement, deprecated, or running in low-capacity regions — then recommend newer replacement SKUs with better availability.
+
+### Proposed Features
+- [ ] **`-Modernize` Parameter** - Interactive mode that discovers deployed VMs and flags at-risk SKUs
+- [ ] **ARG Inventory Scan** - Use Azure Resource Graph to enumerate all deployed VMs by region, SKU, and resource group
+- [ ] **Retirement Detection** - Cross-reference deployed SKUs against Azure's published retirement/deprecation schedule (Compute RP `resourceSkus` with `NotAvailableForNewDeployments` restrictions)
+- [ ] **Low-Capacity Flagging** - Identify deployed SKUs where current capacity status is `NotAvailable` or `Restricted` in the deployment region
+- [ ] **Upgrade Recommendations** - For each at-risk SKU, run the existing similarity scoring engine (`-Recommend`) to suggest newer replacements with `Available` capacity
+- [ ] **Generation Gap Detection** - Flag VMs running on older generations (v2/v3/v4) when v5/v6 equivalents exist in the same family
+- [ ] **Side-by-Side Comparison** - Table showing current SKU vs recommended upgrade with vCPU, memory, pricing, and capacity delta
+- [ ] **Migration Impact Summary** - Per-VM output: resource group, VM name, current SKU, risk reason, top recommendation, pricing delta
+- [ ] **Export Support** - CSV/XLSX/JSON export of modernization report for fleet planning
+
+### Data Sources
+- **Deployed VMs:** Azure Resource Graph (`Microsoft.Compute/virtualMachines`)
+- **SKU Retirement Status:** Compute RP `resourceSkus` API — restrictions array contains `NotAvailableForNewDeployments` for retiring SKUs
+- **Capacity Status:** Existing capacity scanning logic (already built)
+- **Replacement Scoring:** Existing `Get-SkuSimilarityScore` engine (already built)
+- **Pricing:** Existing retail/negotiated pricing pipeline (already built)
+
+### Interactive Flow
+1. Scan subscription via ARG → list all unique deployed SKUs by region
+2. Check each SKU for retirement restrictions and capacity status
+3. Flag at-risk SKUs (retiring, restricted, low capacity)
+4. For each flagged SKU, run recommend engine to find available replacements
+5. Present color-coded summary: green (healthy), yellow (low capacity), red (retiring/unavailable)
+6. User selects which replacements to include in export report
+
+### Dependencies
+- Benefits from **ARG Integration** backlog items (VM inventory, cross-subscription discovery)
+- Reuses **v1.8.0 Recommend Engine** (`Get-SkuSimilarityScore`, `-Recommend`, `-TopN`)
+- Reuses **v1.3.0 Pricing** pipeline for cost delta calculations
+
+### Notes
+- `NotAvailableForNewDeployments` in the `resourceSkus` restrictions array is the programmatic signal for SKU retirement — no scraping of retirement announcement pages needed
+- Existing VMs on retiring SKUs continue to run but cannot be resized, redeployed after deallocation, or added to scale sets
+- Generation detection heuristic: parse version suffix from SKU name (e.g., `Standard_D4s_v3` → v3, compare against `Standard_D4s_v5` → v5)
 
 ---
 


### PR DESCRIPTION
## Fleet MVP — BOM-Level Readiness Validation

Adds `-Fleet` hashtable parameter for validating a VM bill-of-materials against live Azure capacity and quota data. Closes #55 (P0 items).

### Changes

**Get-AzVMAvailability.ps1**
- `-Fleet` parameter: accepts `@{'Standard_D2s_v5'=17; 'Standard_D4s_v5'=4}` (SKU → VM count)
- Fleet key normalization: strips `Standard_Standard_` double-prefix, adds `Standard_` to bare names
- `Get-FleetReadiness` function (~120 lines): validates fleet BOM against scan data, per-SKU capacity check, per-family quota aggregation with fuzzy name matching fallback
- `Write-FleetReadinessSummary` function (~70 lines): color-coded console with per-SKU table + per-family quota (Used/Available/Limit) + overall PASS/FAIL verdict

**P0 Fixes (from #55)**
- Double-prefix guard: `Standard_Standard_D2s_v5` normalizes correctly
- Show used quota: Added `Used` column to quota validation table
- Quota family matching: substring fallback when `$sku.Family` doesn't exactly match `Get-AzVMUsage` `Name.Value`

**Housekeeping**
- Release workflow: push-to-main now auto-publishes (not draft); release notes editable on GitHub without PR round-trip
- Removed duplicate SKU Modernization section from ROADMAP
- Added `.tmp_*` to `.gitignore`

### Live Test Results
Tested on ACE-Datalake-Dev (eastus): 5/5 SKUs OK, 3 quota families PASS (350 vCPU each).
Tested on IHIS-DEV (eastus): 4/5 LIMITED, quota shows `?` (Microsoft.Compute not registered).

### Checklist
- [x] Syntax validation passes
- [x] PSScriptAnalyzer clean
- [x] Live tested on 2 subscriptions
- [x] CHANGELOG.md updated
- [x] Copilot review comments triaged
