### PR TITLE
fix: make dashboard generator CI-safe

### DIFF
--- a/tools/Generate-TrafficDashboard-Premium-v2.ps1
+++ b/tools/Generate-TrafficDashboard-Premium-v2.ps1
@@ -772,6 +772,10 @@ function setRange(days, el) {
 #region Write and Open
 $html | Out-File -FilePath $OutputFile -Encoding UTF8
 Write-Host "`nDashboard generated: $OutputFile" -ForegroundColor Green
-Write-Host "Opening in browser..." -ForegroundColor Gray
-Start-Process $OutputFile
+if ($env:CI -ne 'true' -and $PSVersionTable.Platform -ne 'Unix') {
+  Write-Host "Opening in browser..." -ForegroundColor Gray
+  Start-Process $OutputFile
+} else {
+  Write-Host "Skipping browser launch in CI/non-Windows environment." -ForegroundColor Gray
+}
 #endregion


### PR DESCRIPTION
Skip Start-Process in CI/non-Windows so collect-traffic workflow can complete in GitHub Actions.