### PR TITLE
fix: revert premature v2.0.0 version bump -- set to 1.12.3

### DIFF
--- a/AzVMAvailability/AzVMAvailability.psd1
+++ b/AzVMAvailability/AzVMAvailability.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule        = 'AzVMAvailability.psm1'
-    ModuleVersion     = '1.12.2'
+    ModuleVersion     = '1.12.3'
     GUID              = 'a7f3b2c1-4d5e-6f78-9a0b-1c2d3e4f5a6b'
     Author            = 'Zachary Luz'
     CompanyName       = 'Community'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.12.3] - 2026-03-21
+
 ### Changed
-- **Module conversion:** Extracted all 34 functions from monolithic `Get-AzVMAvailability.ps1` into `AzVMAvailability/` module with Private/ subdirectory layout (#5)
+- **Module scaffold:** Extracted all 34 functions from monolithic `Get-AzVMAvailability.ps1` into `AzVMAvailability/` module with Private/ subdirectory layout (#5)
 - Root script now imports `AzVMAvailability` module instead of defining functions inline (2,028 lines removed from main script)
 - Removed dead `$script:CachedValidRegions` variable
 
 ### Added
-- `AzVMAvailability/AzVMAvailability.psd1` — module manifest (PSGallery-ready, declares Az module dependencies)
-- `AzVMAvailability/AzVMAvailability.psm1` — dependency-ordered dot-source loader
+- `AzVMAvailability/AzVMAvailability.psd1` -- module manifest (declares Az module dependencies)
+- `AzVMAvailability/AzVMAvailability.psm1` -- dependency-ordered dot-source loader
 - 34 function files across `Private/Azure/`, `Private/SKU/`, `Private/Image/`, `Private/Fleet/`, `Private/Format/`, `Private/Utility/`
-- `Find-FunctionInModule` in TestHarness.psm1 — module-aware function discovery with AST caching and parse error checking
+- `Find-FunctionInModule` in TestHarness.psm1 -- module-aware function discovery with AST caching and parse error checking
 
 ## [1.12.2] - 2026-03-20
 

--- a/Get-AzVMAvailability.ps1
+++ b/Get-AzVMAvailability.ps1
@@ -125,7 +125,7 @@
     Name:           Get-AzVMAvailability
     Author:         Zachary Luz
     Created:        2026-01-21
-    Version:        1.12.2
+    Version:        1.12.3
     License:        MIT
     Repository:     https://github.com/zacharyluz/Get-AzVMAvailability
 
@@ -456,7 +456,7 @@ if ($Fleet -and $Fleet.Count -gt 0) {
 }
 
 #region Configuration
-$ScriptVersion = "1.12.2"
+$ScriptVersion = "1.12.3"
 
 #region Constants
 $HoursPerMonth = 730

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A PowerShell tool for checking Azure VM SKU availability across regions - find w
 ![PowerShell](https://img.shields.io/badge/PowerShell-7.0%2B-blue)
 ![Azure](https://img.shields.io/badge/Azure-Az%20Modules-0078D4)
 ![License](https://img.shields.io/badge/License-MIT-green)
-![Version](https://img.shields.io/badge/Version-1.12.2-brightgreen)
+![Version](https://img.shields.io/badge/Version-1.12.3-brightgreen)
 
 ## Disclosure & Disclaimer
 
@@ -399,7 +399,7 @@ SKUs that are available but **incompatible** with your image are shown in dark y
 ### Console Output (with Pricing)
 ```
 ====================================================================================
-GET-AZVMAVAILABILITY v1.12.2
+GET-AZVMAVAILABILITY v1.12.3
 ====================================================================================
 SKU Filter: Standard_D2s_v5 | Pricing: Enabled
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-## Current Release: v1.12.2
+## Current Release: v1.12.3
 
 See [CHANGELOG.md](CHANGELOG.md) for full version history.
 

--- a/demo/DEMO-GUIDE.md
+++ b/demo/DEMO-GUIDE.md
@@ -1,6 +1,6 @@
 # Get-AzVMAvailability — Live Demo Guide
 
-**Version:** 1.12.2 | **Duration:** ~40 minutes + Q&A | **Audience:** Internal Microsoft / External Customers
+**Version:** 1.12.3 | **Duration:** ~40 minutes + Q&A | **Audience:** Internal Microsoft / External Customers
 
 ---
 


### PR DESCRIPTION
## Summary

Reverts the premature v2.0.0 version bump from PR #89. The module scaffold merged but the module is not yet complete for a major release. Bumped to 1.12.3 (not 1.12.2) to avoid reusing an already-tagged version.

## Changes

- Set all 8 version locations to 1.12.3
- Added [1.12.3] CHANGELOG section for the module scaffold changes
- Deleted the auto-created v2.0.0 GitHub release and tag

## Quality Checklist

- [x] **Version strings in sync** -- all locations set to 1.12.3
- [x] **CHANGELOG.md updated** -- [1.12.3] section with module scaffold entries
- [x] **Release/tag plan prepared for this version bump** -- 1.12.3 release expected after merge
