### PR TITLE
fix: add 'edited' trigger to release-metadata-guard workflow

### DIFF
--- a/.github/workflows/release-metadata-guard.yml
+++ b/.github/workflows/release-metadata-guard.yml
@@ -3,6 +3,7 @@ name: "Release Metadata Guard"
 on:
   pull_request:
     branches: ["main"]
+    types: [opened, synchronize, reopened, edited]
   workflow_dispatch:
 
 permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Added `edited` trigger type to `release-metadata-guard.yml` so PR body checkbox changes re-run the guard without needing an empty commit workaround
+
 ### Changed
 - Broadened `.gitignore` patterns for session/handoff docs (`docs/*handoff*`, `docs/*session-notes*`)
 - Removed accidentally committed session docs from tracking (local copies preserved in `docs/archive/`)


### PR DESCRIPTION
## Summary

Adds `edited` to the `pull_request` trigger types on `release-metadata-guard.yml`.

### Problem

When a PR body is edited (e.g., checking the release plan checkbox), the guard workflow doesn't re-run because GitHub Actions defaults to `[opened, synchronize, reopened]` — missing the `edited` event type. This forces an empty commit workaround to trigger re-evaluation.

### Fix

Add `types: [opened, synchronize, reopened, edited]` to the workflow trigger, so PR body changes (including checkbox state) automatically re-run the guard.

### Changes

- `.github/workflows/release-metadata-guard.yml` — added `edited` trigger type
- `CHANGELOG.md` — documented fix under `[Unreleased]`

### Checklist

- [x] CHANGELOG.md updated
- [x] No version bump (CI/workflow-only change)
