### PR TITLE
feat: dynamic dashboard metrics with WoW trends and insights

### DIFF
--- a/tools/Generate-TrafficDashboard-Premium-v2.ps1
+++ b/tools/Generate-TrafficDashboard-Premium-v2.ps1
@@ -115,9 +115,9 @@ function Get-RollingDelta {
     $cutoff = ([datetime]$sorted[-1].Date).AddDays(-$WindowDays)
     $priorCutoff = $cutoff.AddDays(-$WindowDays)
 
-    $current = ($sorted | Where-Object { [datetime]$_.Date -gt $cutoff } |
+    $current = ($sorted | Where-Object { [datetime]$_.Date -ge $cutoff } |
         ForEach-Object { [int]$_.$ValueProperty } | Measure-Object -Sum).Sum
-    $prior = ($sorted | Where-Object { [datetime]$_.Date -gt $priorCutoff -and [datetime]$_.Date -le $cutoff } |
+    $prior = ($sorted | Where-Object { [datetime]$_.Date -ge $priorCutoff -and [datetime]$_.Date -lt $cutoff } |
         ForEach-Object { [int]$_.$ValueProperty } | Measure-Object -Sum).Sum
 
     $delta = if ($prior -gt 0) { [math]::Round(($current - $prior) / $prior * 100) } else { 0 }
@@ -506,10 +506,20 @@ $html += @"
 "@
 
 # Metrics — single unified bar with 6 cells, no orphans
-$viewDeltaClass = if ($viewDelta -gt 0) { 'up' } elseif ($viewDelta -lt 0) { 'down' } else { 'flat' }
-$viewDeltaArrow = if ($viewDelta -gt 0) { '&#8593;' } elseif ($viewDelta -lt 0) { '&#8595;' } else { '&#8594;' }
-$cloneDeltaClass = if ($cloneDelta -gt 0) { 'up' } elseif ($cloneDelta -lt 0) { 'down' } else { 'flat' }
-$cloneDeltaArrow = if ($cloneDelta -gt 0) { '&#8593;' } elseif ($cloneDelta -lt 0) { '&#8595;' } else { '&#8594;' }
+$viewDeltaHtml = if ($viewsWoW.HasData) {
+    $cls = if ($viewDelta -gt 0) { 'up' } elseif ($viewDelta -lt 0) { 'down' } else { 'flat' }
+    $arrow = if ($viewDelta -gt 0) { '&#8593;' } elseif ($viewDelta -lt 0) { '&#8595;' } else { '&#8594;' }
+    "<div class=`"m-delta $cls`" id=`"hdr-views-delta`">$arrow ${viewDelta}% WoW</div>"
+} else {
+    '<div class="m-delta flat" id="hdr-views-delta">&mdash;</div>'
+}
+$cloneDeltaHtml = if ($clonesWoW.HasData) {
+    $cls = if ($cloneDelta -gt 0) { 'up' } elseif ($cloneDelta -lt 0) { 'down' } else { 'flat' }
+    $arrow = if ($cloneDelta -gt 0) { '&#8593;' } elseif ($cloneDelta -lt 0) { '&#8595;' } else { '&#8594;' }
+    "<div class=`"m-delta $cls`" id=`"hdr-clones-delta`">$arrow ${cloneDelta}% WoW</div>"
+} else {
+    '<div class="m-delta flat" id="hdr-clones-delta">&mdash;</div>'
+}
 
 $html += @"
   <div class="metrics reveal d1">
@@ -517,13 +527,13 @@ $html += @"
       <div class="m-label" id="hdr-views-label">Views (All Time)</div>
       <div class="m-value" id="hdr-views-value">$totalViewsAllTime</div>
       <div class="m-sub" id="hdr-views-sub">$uniqueViewsAllTime unique</div>
-      <div class="m-delta $viewDeltaClass" id="hdr-views-delta">$viewDeltaArrow ${viewDelta}% WoW</div>
+      $viewDeltaHtml
     </div>
     <div class="metric">
       <div class="m-label" id="hdr-clones-label">Clones (All Time)</div>
       <div class="m-value" id="hdr-clones-value">$totalClonesAllTime</div>
       <div class="m-sub" id="hdr-clones-sub">$uniqueClonesAllTime unique</div>
-      <div class="m-delta $cloneDeltaClass" id="hdr-clones-delta">$cloneDeltaArrow ${cloneDelta}% WoW</div>
+      $cloneDeltaHtml
     </div>
     <div class="metric">
       <div class="m-label">Stars</div>


### PR DESCRIPTION
## Summary
Replaces the misleading day-over-day traffic deltas with proper rolling-window comparisons and adds new computed metrics to the GitHub Pages traffic dashboard.

## Changes
- **Dynamic header cards** — Views/Clones labels, values, unique counts, and % deltas all update when switching time ranges (7d / 14d / 28d / 91d / All Time)
- **Rolling window deltas** — WoW comparison instead of single day-over-day noise (old: ↑39%/↓-60% from two random days; new: proper 7d-vs-prior-7d)
- **Insights row** (4 new metric cards):
  - View → Clone Rate (intent quality)
  - Avg Daily Views (smoothed baseline)
  - Peak Day (highest single-day with date)
  - Days Since Last Star (freshness indicator)
- **Weekly Trends table** — ISO-week buckets with Views, Clones, WoW % arrows, and per-week Clone Rate
- **`Get-RollingDelta`** PowerShell function for server-side initial value computation

## Before / After
**Before:** Day-over-day delta comparing Apr 2 (23 views) vs Apr 3 (32 views) = ↑39%. Meaningless noise.
**After:** 7d vs prior 7d: 361 vs 363 = -1% WoW. Accurate trajectory.

## Testing
- Generated dashboard locally from 43 days of historical CSV data
- Verified all time range selections update header + insights + weekly table
- Confirmed JS brace balance (193/193)
- No new data collection dependencies — all computed from existing CSVs

## Summary by Sourcery

Replace day-over-day traffic deltas with rolling-window comparisons and enrich the GitHub Pages traffic dashboard with dynamic header metrics, insights, and weekly trends.

New Features:
- Add rolling-window week-over-week and 14-day comparison logic for views and clones, including a reusable Get-RollingDelta helper.
- Introduce dynamic header cards whose labels, totals, uniques, and percentage deltas update based on the selected date range, with all-time totals surfaced inline.
- Add an insights row with computed metrics such as view-to-clone rate, average daily views, peak day, and days since last star.
- Add a Weekly Trends table that buckets data into ISO weeks and shows per-week totals, WoW percentage changes, and clone rate.

Enhancements:
- Update charts and summary stats to use all-time totals, while range selection now drives a dedicated metrics updater for more accurate comparisons and insights.