### PR TITLE
feat: collect traffic 4x/day + trigger on star and fork events

### DIFF
--- a/.github/workflows/collect-traffic.yml
+++ b/.github/workflows/collect-traffic.yml
@@ -2,9 +2,12 @@ name: Collect Traffic Data
 
 on:
   schedule:
-    # Run daily at 06:00 UTC (1-2 AM ET depending on DST)
-    - cron: '0 6 * * *'
-  workflow_dispatch: # Allow manual trigger
+    # Run 4x/day at 00:00, 06:00, 12:00, 18:00 UTC
+    - cron: '0 0,6,12,18 * * *'
+  watch:
+    types: [started]   # star event
+  fork:                # fork event
+  workflow_dispatch:   # manual trigger
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
Increases traffic collection frequency and adds event-driven triggers for stars and forks.

## Changes
- **4x/day collection:** Cron schedule changed from `0 6 * * *` (1x/day) to `0 0,6,12,18 * * *` (every 6 hours)
- **Star trigger:** `watch: started` fires the workflow when someone stars the repo — dashboard updates within minutes
- **Fork trigger:** `fork` event fires the workflow when someone forks — same immediate update
- **Manual dispatch preserved** for on-demand runs

## Why
- GitHub Traffic API returns daily aggregates, but collecting 4x/day captures the current day's partial count sooner
- Star and fork events are instant — the dashboard can reflect them within ~2 minutes instead of waiting up to 24 hours
- GitHub Actions cost: ~4 min/day of runner time (was ~1 min/day)

## Summary by Sourcery

Build:
- Update the GitHub Actions workflow to run four times daily instead of once and to trigger on star, fork, and manual dispatch events.