### PR TITLE
fix: add concurrency group and reduce to 2x/day (PR #116 review)

### DIFF
--- a/.github/workflows/collect-traffic.yml
+++ b/.github/workflows/collect-traffic.yml
@@ -2,12 +2,18 @@ name: Collect Traffic Data
 
 on:
   schedule:
-    # Run 4x/day at 00:00, 06:00, 12:00, 18:00 UTC
-    - cron: '0 0,6,12,18 * * *'
+    # Run 2x/day at ~8 AM and ~8 PM ET (12:00 and 00:00 UTC during EDT)
+    - cron: '0 0,12 * * *'
   watch:
-    types: [started]   # star event
-  fork:                # fork event
+    types: [started]   # star event — rebuilds stars.csv immediately
+  fork:                # fork event — updates repo-stats.csv immediately
   workflow_dispatch:   # manual trigger
+
+# Prevent concurrent runs from racing on git push to traffic-data branch.
+# cancel-in-progress discards redundant runs when multiple stars arrive in a burst.
+concurrency:
+  group: collect-traffic
+  cancel-in-progress: true
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
Addresses review comments from PR #116 that were merged before triage.

## Findings Addressed
1. **Copilot + Sourcery:** Concurrent runs can race on `git push` to `traffic-data` — added `concurrency` group with `cancel-in-progress: true`
2. **Copilot:** Views/clones merge logic is append-only per date, so 4x/day produces no additional data — reduced to 2x/day (00:00, 12:00 UTC)
3. **Copilot:** Full stargazer pagination on every star — mitigated by `cancel-in-progress` which drops redundant burst runs

## What Still Benefits From Multiple Runs
- `stars.csv` — rebuilt from scratch each run (no dedup)
- `repo-stats.csv` — one snapshot per date (second run catches intra-day changes)
- `release-downloads.csv` — same as repo-stats
- Star/fork event triggers remain for immediate dashboard updates

## Summary by Sourcery

Adjust traffic data collection workflow scheduling and concurrency to reduce redundant runs and avoid concurrent push conflicts.

CI:
- Reduce scheduled traffic data collection from four to two daily runs while retaining star and fork event triggers.
- Add a concurrency group with cancel-in-progress to prevent overlapping workflow runs from racing on git pushes.