### PR TITLE
fix: remove unused resourceId variable (GHAS #76)

### DIFF
--- a/Get-AzVMAvailability.ps1
+++ b/Get-AzVMAvailability.ps1
@@ -1344,7 +1344,6 @@ function Get-AdvisorRetirementData {
                 $retireDate = $props.extendedProperties.retirementDate
                 $seriesName = $props.extendedProperties.retirementFeatureName
                 $vmName = $props.impactedValue
-                $resourceId = $props.resourceMetadata.resourceId
                 $impact = $props.impact
 
                 # Parse the SKU from the resource ID if available (need separate ARG query for that)


### PR DESCRIPTION
Removes unused assignment at line 1347 in Get-AdvisorRetirementData. Resolves code scanning alert #76 (PSUseDeclaredVarsMoreThanAssignments).

## Summary by Sourcery

Bug Fixes:
- Resolve a PSUseDeclaredVarsMoreThanAssignments code scanning alert by deleting an unused resourceId variable.