### PR TITLE
fix: README banner not displaying

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 <p align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="assets/header-dark.png" />
-    <source media="(prefers-color-scheme: light)" srcset="assets/header.png" />
-    <img src="assets/header-dark.png" alt="Get-AzVMAvailability — Discover Available Azure VM Capacity Across Regions" />
-  </picture>
+  <img src="assets/header-dark.png" alt="Get-AzVMAvailability — Discover Available Azure VM Capacity Across Regions" />
 </p>
 
 A PowerShell tool for checking Azure VM SKU availability across regions - find where your VMs can deploy.


### PR DESCRIPTION
Remove \<picture>\ tag referencing missing \ssets/header.png\ (light mode). Use direct \<img>\ with \header-dark.png\ until a light version is added.

## Verification Checklist
### Verified Landmark Table
| Landmark | Evidence | Tag |
|---|---|---|
| header-dark.png exists in assets/ | git ls-files assets/ | [OBSERVED] |
| header.png does not exist | Test-Path returns False | [OBSERVED] |

### Behavior Parity
- [x] No code changes — docs only

## Quality Checklist
- [x] **Release/tag plan prepared for this version bump** — no version change

## Summary by Sourcery

Documentation:
- Update README banner to use the existing header-dark image and remove reference to the missing light-mode asset.