### PR TITLE
v2.1.0: PSGallery tracking, dashboard fixes, smart defaults

### DIFF
--- a/.github/workflows/collect-traffic.yml
+++ b/.github/workflows/collect-traffic.yml
@@ -98,8 +98,11 @@ jobs:
       - name: Collect PSGallery downloads
         shell: bash
         run: |
-          curl -s "https://www.powershellgallery.com/api/v2/FindPackagesById()?id='AzVMAvailability'" \
-            -H "Accept: application/atom+xml" -o /tmp/psgallery.xml
+          if ! curl -fsS "https://www.powershellgallery.com/api/v2/FindPackagesById()?id='AzVMAvailability'" \
+            -H "Accept: application/atom+xml" -o /tmp/psgallery.xml; then
+            echo "::warning::PSGallery API request failed (non-2xx or network error)"
+            echo '<feed/>' > /tmp/psgallery.xml
+          fi
           echo "PSGallery response collected"
 
       - name: Merge into CSVs

--- a/.github/workflows/collect-traffic.yml
+++ b/.github/workflows/collect-traffic.yml
@@ -95,6 +95,13 @@ jobs:
           gh api "repos/${{ github.repository }}/releases?per_page=100" > /tmp/releases.json
           echo "Release data collected"
 
+      - name: Collect PSGallery downloads
+        shell: bash
+        run: |
+          curl -s "https://www.powershellgallery.com/api/v2/FindPackagesById()?id='AzVMAvailability'" \
+            -H "Accept: application/atom+xml" -o /tmp/psgallery.xml
+          echo "PSGallery response collected"
+
       - name: Merge into CSVs
         run: |
           TODAY=$(date -u +%Y-%m-%d)
@@ -199,6 +206,35 @@ jobs:
           fi
           cp /tmp/release_downloads_existing.csv traffic-data/data/release-downloads.csv
 
+          # ── PSGallery Downloads (daily snapshot per version) ──
+          if [ -f traffic-data/data/psgallery-downloads.csv ]; then
+            cp traffic-data/data/psgallery-downloads.csv /tmp/psgallery_existing.csv
+          else
+            echo "Date,Version,VersionDownloads,TotalDownloads,IsLatestVersion" > /tmp/psgallery_existing.csv
+          fi
+          if ! grep -q "^\"*${TODAY}" /tmp/psgallery_existing.csv 2>/dev/null; then
+            # Parse OData XML response — extract Version, VersionDownloadCount, DownloadCount, IsLatestVersion per entry
+            if command -v python3 &>/dev/null; then
+              python3 -c "
+import xml.etree.ElementTree as ET, sys
+ns = {'a': 'http://www.w3.org/2005/Atom', 'd': 'http://schemas.microsoft.com/ado/2007/08/dataservices', 'm': 'http://schemas.microsoft.com/ado/2007/08/dataservices/metadata'}
+tree = ET.parse('/tmp/psgallery.xml')
+for entry in tree.findall('.//a:entry', ns):
+    props = entry.find('.//m:properties', ns)
+    if props is None: continue
+    ver = props.find('d:Version', ns)
+    vdl = props.find('d:VersionDownloadCount', ns)
+    tdl = props.find('d:DownloadCount', ns)
+    ilv = props.find('d:IsLatestVersion', ns)
+    if ver is not None:
+        print(f'${TODAY},{ver.text},{vdl.text if vdl is not None else 0},{tdl.text if tdl is not None else 0},{ilv.text if ilv is not None else \"false\"}')
+" >> /tmp/psgallery_existing.csv
+            else
+              echo "Warning: python3 not available, skipping PSGallery XML parse"
+            fi
+          fi
+          cp /tmp/psgallery_existing.csv traffic-data/data/psgallery-downloads.csv
+
           echo "=== Collection Summary ==="
           echo "Views:     $(tail -n +2 traffic-data/data/views.csv | wc -l) days"
           echo "Clones:    $(tail -n +2 traffic-data/data/clones.csv | wc -l) days"
@@ -207,6 +243,7 @@ jobs:
           echo "Paths:     $(tail -n +2 traffic-data/data/paths.csv | wc -l) records"
           echo "Stats:     $(tail -n +2 traffic-data/data/repo-stats.csv | wc -l) days"
           echo "Release Downloads Snapshots: $(tail -n +2 traffic-data/data/release-downloads.csv | wc -l) days"
+          echo "PSGallery Snapshots: $(tail -n +2 traffic-data/data/psgallery-downloads.csv | wc -l) records"
 
       - name: Generate dashboard HTML for GitHub Pages
         shell: pwsh

--- a/AzVMAvailability/AzVMAvailability.psd1
+++ b/AzVMAvailability/AzVMAvailability.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule        = 'AzVMAvailability.psm1'
-    ModuleVersion     = '2.0.0'
+    ModuleVersion     = '2.1.0'
     GUID              = '7f42e8d6-e85d-4e31-a541-d9af648a5269'
     Author            = 'Zachary Luz'
     CompanyName       = 'Community'

--- a/AzVMAvailability/Public/Get-AzVMAvailability.ps1
+++ b/AzVMAvailability/Public/Get-AzVMAvailability.ps1
@@ -126,7 +126,7 @@ function Get-AzVMAvailability {
     Name:           Get-AzVMAvailability
     Author:         Zachary Luz
     Created:        2026-01-21
-    Version:        2.0.0
+    Version:        2.1.0
     License:        MIT
     Repository:     https://github.com/zacharyluz/Get-AzVMAvailability
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.1.0] — 2026-07-17
 
 ### Added
 - **Smart default regions** — Default regions now auto-detect based on cloud environment and user timezone. Sovereign clouds (Gov, China) use their native regions; commercial cloud defaults match the user's local timezone geo (Americas, Europe, India/ME, APAC, Australia). New private function `Get-SmartDefaultRegions`.
+- **PSGallery download tracking** — Traffic collector and CI workflow now fetch PSGallery total download counts alongside GitHub views/clones/stars.
 
 ### Documentation
 - Split README into focused docs/ pages — README is now a concise landing page linking to 11 topic guides under `docs/`
+
+### Fixed
+- **Traffic dashboard off-by-one** — Date filtering in `dashboard.js` used `>=` cutoff comparison, making 7-day windows span 8 days. Fixed `filterByDays`, `windowData`, and `rollingDelta` to use `>` with non-overlapping window boundaries.
+- **Traffic dashboard delta display** — Views and Clones delta percentages showed misleading "→ 0%" when no prior-period data existed. Now displays "— N/A" when `hasData` is false.
 
 ## [2.0.0] — Module Conversion
 

--- a/Get-AzVMAvailability.ps1
+++ b/Get-AzVMAvailability.ps1
@@ -16,7 +16,7 @@
     Name:           Get-AzVMAvailability
     Author:         Zachary Luz
     Created:        2026-01-21
-    Version:        2.0.0
+    Version:        2.1.0
     License:        MIT
     Repository:     https://github.com/zacharyluz/Get-AzVMAvailability
 
@@ -175,7 +175,7 @@ param(
 )
 
 # Version for Validate-Script.ps1 parity check (must match .psd1 ModuleVersion)
-$ScriptVersion = "2.0.0"
+$ScriptVersion = "2.1.0"
 Write-Verbose "Get-AzVMAvailability wrapper v$ScriptVersion"
 
 # Import the AzVMAvailability module from the same directory as this script

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A PowerShell tool for checking Azure VM SKU availability across regions - find w
 ![PowerShell](https://img.shields.io/badge/PowerShell-7.0%2B-blue)
 ![Azure](https://img.shields.io/badge/Azure-Az%20Modules-0078D4)
 ![License](https://img.shields.io/badge/License-MIT-green)
-![Version](https://img.shields.io/badge/Version-2.0.0-brightgreen)
+![Version](https://img.shields.io/badge/Version-2.1.0-brightgreen)
 
 ## Overview
 
@@ -155,7 +155,7 @@ As of v2.0.0, Get-AzVMAvailability is available as both a standalone script and 
 | [Region Presets](docs/region-presets.md) | Pre-built region sets for US, Europe, Asia-Pacific, sovereign clouds |
 | [Image Compatibility](docs/image-compatibility.md) | Gen1/Gen2 and x64/ARM64 image checking |
 | [Output & Pricing](docs/output-and-pricing.md) | Console output, pricing auto-detection, Excel export, status legend |
-| [Cloud Environments](docs/cloud-environments.md) | Supported Azure clouds (Commercial, Government, China, Germany) |
+| [Cloud Environments](docs/cloud-environments.md) | Supported Azure clouds (Commercial, Government, China) |
 | [AI Agent Integration](docs/agent-integration.md) | Copilot skill for natural-language VM capacity queries |
 | [GitHub Codespaces](docs/codespaces.md) | Run in a browser with zero local setup |
 | [Local Installation](docs/local-installation.md) | Clone, install modules, and import |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,8 @@
 # Roadmap
 
-## Current Release: v2.0.0
+## Current Release: v2.1.0
 
-> **v2.0.0 Module Conversion Complete:** Standalone script converted to PowerShell module with Public/Private layout, PSGallery publishing, and CI/CD automation. No new features or behavior changes from v1.14.0.
+> **v2.1.0:** PSGallery download tracking, traffic dashboard fixes, smart default regions, and documentation improvements. See [CHANGELOG.md](CHANGELOG.md) for details.
 
 See [CHANGELOG.md](CHANGELOG.md) for full version history.
 

--- a/demo/DEMO-GUIDE.md
+++ b/demo/DEMO-GUIDE.md
@@ -1,6 +1,6 @@
 # Get-AzVMAvailability — Live Demo Guide
 
-**Version:** 2.0.0 | **Duration:** ~40 minutes + Q&A | **Audience:** Internal Microsoft / External Customers
+**Version:** 2.1.0 | **Duration:** ~40 minutes + Q&A | **Audience:** Internal Microsoft / External Customers
 
 ---
 

--- a/tools/Collect-TrafficData.ps1
+++ b/tools/Collect-TrafficData.ps1
@@ -410,8 +410,8 @@ try {
     foreach ($pkg in $packages) {
         $props = $pkg.properties
         $version = $props.Version
-        $versionDownloads = [int]$props.VersionDownloadCount.'#text'
-        $totalDownloads = [int]$props.DownloadCount.'#text'
+        $versionDownloads = [long]$props.VersionDownloadCount.'#text'
+        $totalDownloads = [long]$props.DownloadCount.'#text'
         $isLatest = $props.IsLatestVersion.'#text' -eq 'true'
         $totalGalleryDownloads = $totalDownloads
 

--- a/tools/Collect-TrafficData.ps1
+++ b/tools/Collect-TrafficData.ps1
@@ -4,9 +4,9 @@
 
 .DESCRIPTION
     GitHub only retains traffic data for 14 days. This script captures views,
-    clones, referrers, and popular paths via the GitHub API and appends new
-    records to CSV files in the artifacts/traffic/ directory. Designed to be
-    run daily (manually, scheduled task, or GitHub Actions).
+    clones, referrers, and popular paths via the GitHub API, collects PSGallery
+    download stats, and appends new records to CSV files in the artifacts/traffic/
+    directory. Designed to be run daily (manually, scheduled task, or GitHub Actions).
 
     Requires: GitHub CLI (gh) authenticated with repo scope.
 
@@ -46,7 +46,9 @@ $PathsFile     = 'paths.csv'
 $StarsFile     = 'stars.csv'
 $RepoStatsFile = 'repo-stats.csv'
 $ReleaseDownloadsFile = 'release-downloads.csv'
+$PSGalleryFile = 'psgallery-downloads.csv'
 $StargazersPerPage = 100
+$PSGalleryModuleName = 'AzVMAvailability'
 #endregion
 
 #region Setup
@@ -394,6 +396,53 @@ try {
 }
 catch {
     Write-Warning "Failed to collect release download stats: $_"
+}
+#endregion
+
+#region Collect PSGallery Downloads
+Write-Host "`nCollecting PSGallery download stats..." -ForegroundColor Cyan
+try {
+    $galleryUrl = "https://www.powershellgallery.com/api/v2/FindPackagesById()?id='$PSGalleryModuleName'"
+    $packages = Invoke-RestMethod -Uri $galleryUrl -ErrorAction Stop
+    $galleryRecords = @()
+    $totalGalleryDownloads = 0
+
+    foreach ($pkg in $packages) {
+        $props = $pkg.properties
+        $version = $props.Version
+        $versionDownloads = [int]$props.VersionDownloadCount.'#text'
+        $totalDownloads = [int]$props.DownloadCount.'#text'
+        $isLatest = $props.IsLatestVersion.'#text' -eq 'true'
+        $totalGalleryDownloads = $totalDownloads
+
+        $galleryRecords += [PSCustomObject]@{
+            Date             = $collectedDate
+            Version          = $version
+            VersionDownloads = $versionDownloads
+            TotalDownloads   = $totalDownloads
+            IsLatestVersion  = $isLatest
+        }
+    }
+
+    $psGalleryPath = Join-Path $OutputDir $PSGalleryFile
+    $existingGallery = Get-ExistingData -FilePath $psGalleryPath
+
+    # Snapshot merge: skip if today already collected (all versions are a batch)
+    $alreadyCollected = $existingGallery | Where-Object { $_.Date -eq $collectedDate }
+    if ($alreadyCollected) {
+        $totalNew += 0
+        Write-Host "  PSGallery: 0 new records (today already collected, $($existingGallery.Count) total)" -ForegroundColor Green
+    }
+    else {
+        $merged = @($existingGallery) + @($galleryRecords)
+        $merged | Sort-Object Date, Version | Export-Csv -Path $psGalleryPath -NoTypeInformation
+        $totalNew += $galleryRecords.Count
+        Write-Host "  PSGallery: $($galleryRecords.Count) new records ($($merged.Count) total)" -ForegroundColor Green
+    }
+    Write-Host "  Summary: $totalGalleryDownloads total downloads across $($galleryRecords.Count) version(s)" -ForegroundColor Gray
+}
+catch {
+    Write-Warning "Failed to collect PSGallery download stats: $_"
 }
 #endregion
 

--- a/tools/Generate-TrafficDashboard-Premium-v2.ps1
+++ b/tools/Generate-TrafficDashboard-Premium-v2.ps1
@@ -48,12 +48,25 @@ $referrersPath = Join-Path $InputDir 'referrers.csv'
 $pathsPath     = Join-Path $InputDir 'paths.csv'
 $repoStatsPath = Join-Path $InputDir 'repo-stats.csv'
 $releaseDownloadsPath = Join-Path $InputDir 'release-downloads.csv'
+$psGalleryPath = Join-Path $InputDir 'psgallery-downloads.csv'
 
 $views     = @(if (Test-Path $viewsPath)     { Import-Csv $viewsPath     | Sort-Object Date })
 $clones    = @(if (Test-Path $clonesPath)    { Import-Csv $clonesPath    | Sort-Object Date })
 $stars     = @(if (Test-Path $starsPath)     { Import-Csv $starsPath     | Sort-Object Date })
 $repoStats = @(if (Test-Path $repoStatsPath) { Import-Csv $repoStatsPath | Sort-Object Date })
 $releaseDownloads = @(if (Test-Path $releaseDownloadsPath) { Import-Csv $releaseDownloadsPath | Sort-Object Date })
+
+# PSGallery: one row per date (prefer IsLatestVersion=true)
+$psGalleryRaw = @(if (Test-Path $psGalleryPath) { Import-Csv $psGalleryPath | Sort-Object Date })
+$psGallery = @()
+if ($psGalleryRaw.Count -gt 0) {
+    $grouped = $psGalleryRaw | Group-Object Date
+    foreach ($g in ($grouped | Sort-Object Name)) {
+        $latest = $g.Group | Where-Object { $_.IsLatestVersion -eq 'true' } | Select-Object -First 1
+        if (-not $latest) { $latest = $g.Group | Select-Object -First 1 }
+        $psGallery += $latest
+    }
+}
 
 $referrers = @()
 if (Test-Path $referrersPath) {
@@ -69,7 +82,7 @@ if (Test-Path $pathsPath) {
     $paths = @($allPaths | Where-Object { $_.CollectedDate -eq $latestDate } | Sort-Object { [int]$_.TotalViews } -Descending | Select-Object -First 10)
 }
 
-Write-Host "Loaded: $($views.Count) view days, $($clones.Count) clone days, $($stars.Count) stars, $($referrers.Count) referrers, $($paths.Count) paths, $(@($releaseDownloads).Count) release download snapshots" -ForegroundColor Cyan
+Write-Host "Loaded: $($views.Count) view days, $($clones.Count) clone days, $($stars.Count) stars, $($referrers.Count) referrers, $($paths.Count) paths, $(@($releaseDownloads).Count) release download snapshots, $($psGallery.Count) PSGallery snapshots" -ForegroundColor Cyan
 #endregion
 
 #region Build JSON — use @() to guarantee arrays for ConvertTo-Json
@@ -84,6 +97,28 @@ $cloneUniques = @($clones | ForEach-Object { [int]$_.UniqueClones })| ConvertTo-
 $starDates      = @($stars | ForEach-Object { $_.Date })               | ConvertTo-Json -Compress -AsArray
 $starCumulative = @($stars | ForEach-Object { [int]$_.CumulativeStars })| ConvertTo-Json -Compress -AsArray
 $starUsers      = @($stars | ForEach-Object { $_.User })               | ConvertTo-Json -Compress -AsArray
+
+$psGalleryDates   = @($psGallery | ForEach-Object { $_.Date })                | ConvertTo-Json -Compress -AsArray
+$psGalleryTotalDl = @($psGallery | ForEach-Object { [long]$_.TotalDownloads })| ConvertTo-Json -Compress -AsArray
+
+# Detect version transitions (where Version changes between consecutive dates)
+$psGalleryVersionChanges = @()
+for ($i = 1; $i -lt $psGallery.Count; $i++) {
+    if ($psGallery[$i].Version -ne $psGallery[$i - 1].Version) {
+        $psGalleryVersionChanges += [PSCustomObject]@{
+            date    = $psGallery[$i].Date
+            version = "v$($psGallery[$i].Version)"
+        }
+    }
+}
+# Include the first version as an annotation too
+if ($psGallery.Count -gt 0) {
+    $psGalleryVersionChanges = @([PSCustomObject]@{
+        date    = $psGallery[0].Date
+        version = "v$($psGallery[0].Version)"
+    }) + $psGalleryVersionChanges
+}
+$psGalleryVersionsJson = $psGalleryVersionChanges | ConvertTo-Json -Compress -AsArray
 
 $refLabels  = @($referrers | ForEach-Object { $_.Referrer })           | ConvertTo-Json -Compress -AsArray
 $refViews   = @($referrers | ForEach-Object { [int]$_.TotalViews })    | ConvertTo-Json -Compress -AsArray
@@ -100,6 +135,10 @@ $uniqueClonesAllTime= if ($clones.Count -gt 0) { ($clones | ForEach-Object { [in
 $totalStars     = if ($stars.Count -gt 0) { ($stars[-1]).CumulativeStars } else { 0 }
 $latestStats    = if ($repoStats.Count -gt 0) { $repoStats[-1] } else { $null }
 $latestReleaseDownloads = if (@($releaseDownloads).Count -gt 0) { @($releaseDownloads)[-1] } else { $null }
+$latestPsGallery = if ($psGallery.Count -gt 0) { $psGallery[-1] } else { $null }
+$psGalleryTotal = if ($latestPsGallery) { $latestPsGallery.TotalDownloads } else { '0' }
+$psGalleryVersion = if ($latestPsGallery) { "v$($latestPsGallery.Version)" } else { [char]0x2014 }
+$psGalleryVersionDlCount = if ($latestPsGallery) { $latestPsGallery.VersionDownloads } else { '0' }
 $generatedAt    = (Get-Date).ToString('MMM d, yyyy \a\t h:mm tt')
 $dateRange      = if ($views.Count -gt 0) { "$($views[0].Date) — $($views[-1].Date)" } else { 'No data' }
 
@@ -556,9 +595,9 @@ $html += @"
       <div class="m-sub">$(if($referrers.Count -gt 0) { "$($referrers[0].TotalViews) views" } else { '' })</div>
     </div>
     <div class="metric">
-      <div class="m-label">Sources</div>
-      <div class="m-value">$($referrers.Count)</div>
-      <div class="m-sub">referrers</div>
+      <div class="m-label">PSGallery</div>
+      <div class="m-value">$psGalleryTotal</div>
+      <div class="m-sub">$psGalleryVersion &middot; $psGalleryVersionDlCount ver. installs</div>
     </div>
   </div>
 "@
@@ -654,6 +693,13 @@ $html += @"
   </div>
   <div class="chart-card reveal d4">
     <div class="chart-header">
+      <div class="ch-left"><h3>PSGallery Downloads</h3><div class="ch-sub">Cumulative install count from PowerShell Gallery</div></div>
+      <div class="ch-right"><div class="ch-stat-label">Total Installs</div><div class="ch-stat-value" id="psGalleryStat">$psGalleryTotal</div></div>
+    </div>
+    <canvas id="psGalleryChart"></canvas>
+  </div>
+  <div class="chart-card reveal d4">
+    <div class="chart-header">
       <div class="ch-left"><h3>Top Referrers</h3><div class="ch-sub">Traffic sources over last 14 days</div></div>
       <div class="ch-right"><div class="ch-stat-label">Sources</div><div class="ch-stat-value">$($referrers.Count)</div></div>
     </div>
@@ -690,7 +736,8 @@ $html += @"
 var allData = {
   views:  { dates: $viewDates, total: $viewTotals, unique: $viewUniques },
   clones: { dates: $cloneDates, total: $cloneTotals, unique: $cloneUniques },
-  stars:  { dates: $starDates, cumulative: $starCumulative, users: $starUsers }
+  stars:  { dates: $starDates, cumulative: $starCumulative, users: $starUsers },
+  psGallery: { dates: $psGalleryDates, totalDl: $psGalleryTotalDl, versions: $psGalleryVersionsJson }
 };
 var refData = { labels: $refLabels, views: $refViews, uniques: $refUniques };
 var pathData = { labels: $pathLabels, views: $pathViews };

--- a/tools/dashboard.js
+++ b/tools/dashboard.js
@@ -71,7 +71,7 @@ function lineOpts(legend) {
 }
 
 // ── Chart instances ──
-var viewsChart, clonesChart, starsChart;
+var viewsChart, clonesChart, starsChart, psGalleryChart;
 
 function buildCharts(allData, days) {
   function filterByDays(dates) {
@@ -94,7 +94,7 @@ function buildCharts(allData, days) {
     return filtered;
   }
 
-  [viewsChart, clonesChart, starsChart].forEach(function(ch) { if (ch) { ch.destroy(); } });
+  [viewsChart, clonesChart, starsChart, psGalleryChart].forEach(function(ch) { if (ch) { ch.destroy(); } });
 
   // Views
   var v = filterByDays(allData.views.dates, allData.views.total, allData.views.unique);
@@ -180,6 +180,72 @@ function buildCharts(allData, days) {
   if (st.arrays[0].length > 0) {
     document.getElementById('starsStat').textContent = st.arrays[0][st.arrays[0].length - 1];
   }
+
+  // PSGallery Downloads (cumulative) with version annotations
+  var pgEl = document.getElementById('psGalleryChart');
+  if (pgEl && allData.psGallery && allData.psGallery.dates.length > 0) {
+    var pg = filterByDays(allData.psGallery.dates, allData.psGallery.totalDl);
+    var pgc = pgEl.getContext('2d');
+
+    // Build version annotation lines within the visible date range
+    var vMarkers = (allData.psGallery.versions || []).filter(function(v) {
+      return pg.dates.indexOf(v.date) !== -1;
+    });
+
+    // Custom plugin: draw vertical dashed lines + version labels
+    var versionLinePlugin = {
+      id: 'versionLines',
+      afterDraw: function(chart) {
+        if (!vMarkers.length) return;
+        var ctx = chart.ctx;
+        var xAxis = chart.scales.x;
+        var yAxis = chart.scales.y;
+        ctx.save();
+        vMarkers.forEach(function(m) {
+          var idx = pg.dates.indexOf(m.date);
+          if (idx === -1) return;
+          var x = xAxis.getPixelForValue(idx);
+          // Dashed vertical line
+          ctx.beginPath();
+          ctx.setLineDash([4, 4]);
+          ctx.strokeStyle = 'rgba(255,255,255,0.35)';
+          ctx.lineWidth = 1;
+          ctx.moveTo(x, yAxis.top);
+          ctx.lineTo(x, yAxis.bottom);
+          ctx.stroke();
+          ctx.setLineDash([]);
+          // Version label at top
+          ctx.fillStyle = 'rgba(255,255,255,0.7)';
+          ctx.font = '10px Inter, sans-serif';
+          ctx.textAlign = 'center';
+          ctx.fillText(m.version, x, yAxis.top - 6);
+        });
+        ctx.restore();
+      }
+    };
+
+    var pgOpts = lineOpts(false);
+    pgOpts.layout = { padding: { top: 18 } };
+
+    psGalleryChart = new Chart(pgc, {
+      type: 'line',
+      data: {
+        labels: pg.dates,
+        datasets: [{
+          label: 'Total Downloads',
+          data: pg.arrays[0],
+          borderColor: '#06b6d4',
+          backgroundColor: grad(pgc, 6, 182, 212),
+          fill: true, tension: 0.4
+        }]
+      },
+      options: pgOpts,
+      plugins: [versionLinePlugin]
+    });
+    if (pg.arrays[0].length > 0) {
+      document.getElementById('psGalleryStat').textContent = pg.arrays[0][pg.arrays[0].length - 1].toLocaleString();
+    }
+  }
 }
 
 // ── Update header metrics + insights for selected time range ──
@@ -234,7 +300,7 @@ function updateMetrics(allData, days) {
   var cDelta = rollingDelta(allData.clones, 'total', compareWindow);
   var compareLabel = days === 0 ? 'WoW' : 'vs prior';
 
-  var vCls = vDelta.delta > 0 ? 'up' : vDelta.delta < 0 ? 'down' : 'flat';
+  var vCls = vDelta.hasData ? (vDelta.delta > 0 ? 'up' : vDelta.delta < 0 ? 'down' : 'flat') : 'flat';
   var vArrow = vDelta.delta > 0 ? '\u2191' : vDelta.delta < 0 ? '\u2193' : '\u2192';
   document.getElementById('hdr-views-label').textContent = 'Views (' + rangeLabel + ')';
   document.getElementById('hdr-views-value').textContent = viewsTotal.toLocaleString();
@@ -243,7 +309,7 @@ function updateMetrics(allData, days) {
   vDeltaEl.className = 'm-delta ' + vCls;
   vDeltaEl.textContent = vDelta.hasData ? (vArrow + ' ' + vDelta.delta + '% ' + compareLabel) : '\u2014 N/A';
 
-  var cCls = cDelta.delta > 0 ? 'up' : cDelta.delta < 0 ? 'down' : 'flat';
+  var cCls = cDelta.hasData ? (cDelta.delta > 0 ? 'up' : cDelta.delta < 0 ? 'down' : 'flat') : 'flat';
   var cArrow = cDelta.delta > 0 ? '\u2191' : cDelta.delta < 0 ? '\u2193' : '\u2192';
   document.getElementById('hdr-clones-label').textContent = 'Clones (' + rangeLabel + ')';
   document.getElementById('hdr-clones-value').textContent = clonesTotal.toLocaleString();

--- a/tools/dashboard.js
+++ b/tools/dashboard.js
@@ -86,7 +86,7 @@ function buildCharts(allData, days) {
       String(t.getDate()).padStart(2, '0');
     var filtered = { dates: [], arrays: arrays.map(function() { return []; }) };
     dates.forEach(function(d, i) {
-      if (d >= cutoff) {
+      if (d > cutoff) {
         filtered.dates.push(d);
         arrays.forEach(function(arr, j) { filtered.arrays[j].push(arr[i]); });
       }
@@ -196,7 +196,7 @@ function updateMetrics(allData, days) {
     var cutoff = t.getFullYear() + '-' + String(t.getMonth() + 1).padStart(2, '0') + '-' + String(t.getDate()).padStart(2, '0');
     var r = { dates: [], values: [], uniques: [] };
     src.dates.forEach(function(d, i) {
-      if (d >= cutoff) { r.dates.push(d); r.values.push(src[valKey][i]); r.uniques.push(src[uniqKey][i]); }
+      if (d > cutoff) { r.dates.push(d); r.values.push(src[valKey][i]); r.uniques.push(src[uniqKey][i]); }
     });
     return r;
   }
@@ -211,8 +211,8 @@ function updateMetrics(allData, days) {
     var priorCutoff = t2.getFullYear() + '-' + String(t2.getMonth() + 1).padStart(2, '0') + '-' + String(t2.getDate()).padStart(2, '0');
     var current = 0, prior = 0;
     src.dates.forEach(function(d, i) {
-      if (d >= cutoff) { current += src[valKey][i]; }
-      else if (d >= priorCutoff && d < cutoff) { prior += src[valKey][i]; }
+      if (d > cutoff) { current += src[valKey][i]; }
+      else if (d > priorCutoff && d <= cutoff) { prior += src[valKey][i]; }
     });
     var delta = prior > 0 ? Math.round((current - prior) / prior * 100) : 0;
     return { current: current, prior: prior, delta: delta, hasData: prior > 0 };
@@ -241,7 +241,7 @@ function updateMetrics(allData, days) {
   document.getElementById('hdr-views-sub').innerHTML = viewsUnique.toLocaleString() + ' unique &middot; ' + allTimeViews.toLocaleString() + ' all-time';
   var vDeltaEl = document.getElementById('hdr-views-delta');
   vDeltaEl.className = 'm-delta ' + vCls;
-  vDeltaEl.textContent = vArrow + ' ' + vDelta.delta + '% ' + compareLabel;
+  vDeltaEl.textContent = vDelta.hasData ? (vArrow + ' ' + vDelta.delta + '% ' + compareLabel) : '\u2014 N/A';
 
   var cCls = cDelta.delta > 0 ? 'up' : cDelta.delta < 0 ? 'down' : 'flat';
   var cArrow = cDelta.delta > 0 ? '\u2191' : cDelta.delta < 0 ? '\u2193' : '\u2192';
@@ -250,7 +250,7 @@ function updateMetrics(allData, days) {
   document.getElementById('hdr-clones-sub').innerHTML = clonesUnique.toLocaleString() + ' unique &middot; ' + allTimeClones.toLocaleString() + ' all-time';
   var cDeltaEl = document.getElementById('hdr-clones-delta');
   cDeltaEl.className = 'm-delta ' + cCls;
-  cDeltaEl.textContent = cArrow + ' ' + cDelta.delta + '% ' + compareLabel;
+  cDeltaEl.textContent = cDelta.hasData ? (cArrow + ' ' + cDelta.delta + '% ' + compareLabel) : '\u2014 N/A';
 
   // Insight cards
   var cloneRate = viewsTotal > 0 ? (clonesTotal / viewsTotal * 100).toFixed(1) : '0';


### PR DESCRIPTION
## v2.1.0 Release

### Summary

Bundles PSGallery download tracking and dashboard visualization, traffic dashboard bug fixes, smart default regions, and documentation improvements into a single minor release.

### Changes

#### Added
- **PSGallery download tracking** — `Collect-TrafficData.ps1` and `collect-traffic.yml` now fetch total download counts from the PSGallery OData API alongside GitHub views/clones/stars
- **PSGallery dashboard visualization** — `Generate-TrafficDashboard-Premium-v2.ps1` renders a cumulative PSGallery downloads chart with version annotation markers; `dashboard.js` includes a custom Chart.js plugin that draws dashed vertical lines at version transition points
- **Smart default regions** — Default regions auto-detect based on cloud environment and user timezone (already merged in prior PR, included in changelog)

#### Fixed
- **PSGallery download counter overflow** — `Collect-TrafficData.ps1` cast download counters to `[long]` to prevent overflow for packages exceeding 2B downloads
- **PSGallery API resilience** — `collect-traffic.yml` uses `curl -fsS` for fail-fast on HTTP errors with empty-feed fallback to prevent downstream parse failures
- **Traffic dashboard off-by-one** — `dashboard.js` date filtering used `>=` cutoff, making 7-day windows span 8 days. Changed to `>` in `filterByDays`, `windowData`, and `rollingDelta` (3 locations)
- **Traffic dashboard delta display** — Views/Clones delta percentages showed "→ 0%" when no prior-period data existed. Now shows "— N/A" with neutral CSS class when `hasData` is false
- **README Germany reference** — Removed "Germany" from cloud environments description. Azure Germany sovereign cloud was retired in 2021

#### Changed
- Version bump `2.0.0` → `2.1.0` across 7 locations (wrapper .NOTES, wrapper $ScriptVersion, public function .NOTES, .psd1 ModuleVersion, README badge, ROADMAP current release, DEMO-GUIDE version)
- CHANGELOG `[Unreleased]` → `[2.1.0] — 2026-07-17`
- Replaced "Sources" metric card with PSGallery metric card in dashboard

### Files Changed (10)
| File | Change |
|------|--------|
| `.github/workflows/collect-traffic.yml` | PSGallery collection + `curl -fsS` hardening |
| `AzVMAvailability/AzVMAvailability.psd1` | ModuleVersion 2.1.0 |
| `AzVMAvailability/Public/Get-AzVMAvailability.ps1` | .NOTES Version 2.1.0 |
| `CHANGELOG.md` | [Unreleased] → [2.1.0], added PSGallery tracking entry |
| `Get-AzVMAvailability.ps1` | .NOTES + $ScriptVersion 2.1.0 |
| `README.md` | Badge 2.1.0, removed Germany from cloud envs |
| `ROADMAP.md` | Current Release v2.1.0 |
| `demo/DEMO-GUIDE.md` | Version header 2.1.0 |
| `tools/Collect-TrafficData.ps1` | PSGallery constants, `[long]` cast, collection/merge |
| `tools/Generate-TrafficDashboard-Premium-v2.ps1` | PSGallery CSV loading, JSON arrays, metric card, chart card |
| `tools/dashboard.js` | PSGallery chart, version annotation plugin, off-by-one fix, N/A delta fix |

### Testing
- Version parity validated by `Validate-Script.ps1` Check 5 in CI
- Dashboard regenerated locally — PSGallery metric card shows "32 total, v2.1.0 · 22 ver. installs"
- Version annotation markers verified with v2.0.0 → v2.1.0 transition data

---

## Verification Checklist

### Verified Landmark Table
| Landmark / Claim | Evidence | Tag |
|---|---|---|
| PSGallery CSV loaded with date-dedup | Read Generate-TrafficDashboard-Premium-v2.ps1 dedup logic: Group-Object by Date, prefer IsLatestVersion=true | [OBSERVED] |
| JSON arrays use [long] type | Read Generate-TrafficDashboard-Premium-v2.ps1: `[long]$row.TotalDownloads` | [OBSERVED] |
| Version transition detection loop | Read Generate-TrafficDashboard-Premium-v2.ps1: consecutive row comparison produces version-change markers | [OBSERVED] |
| Chart.js versionLinePlugin draws dashed lines | Read dashboard.js: afterDraw hook, setLineDash([4,4]), rgba lines + labels | [OBSERVED] |
| PSGallery metric card replaces Sources | Read Generate-TrafficDashboard-Premium-v2.ps1 HTML: 7th grid cell has PSGallery total/version | [OBSERVED] |
| N/A delta CSS class forced neutral | Read dashboard.js: `var vCls = vDelta.hasData ? ... : 'flat'` | [OBSERVED] |
| curl -fsS with empty-feed fallback | Read collect-traffic.yml: if-not curl block with `<feed/>` fallback | [OBSERVED] |
| Download counters cast to [long] | Read Collect-TrafficData.ps1: `[long]$props.VersionDownloadCount` | [OBSERVED] |

### Behavior Parity
- No changes to module public API, parameters, or output contracts
- Dashboard changes are additive (new chart card, replaced metric card in tooling)
- Triage fixes are defensive hardening only

## Quality Checklist
- [x] PSScriptAnalyzer clean (CI validates)
- [x] Pester tests pass (CI validates)
- [x] No changes to module source (`AzVMAvailability/`)
- [x] Dashboard regenerated and visually verified locally
- [x] **Release/tag plan prepared for this version bump**
