### PR TITLE
fix: indent Python block in collect-traffic.yml to fix YAML parse error

### DIFF
--- a/.github/workflows/collect-traffic.yml
+++ b/.github/workflows/collect-traffic.yml
@@ -219,19 +219,20 @@ jobs:
             # Parse OData XML response — extract Version, VersionDownloadCount, DownloadCount, IsLatestVersion per entry
             if command -v python3 &>/dev/null; then
               python3 -c "
-import xml.etree.ElementTree as ET, sys
-ns = {'a': 'http://www.w3.org/2005/Atom', 'd': 'http://schemas.microsoft.com/ado/2007/08/dataservices', 'm': 'http://schemas.microsoft.com/ado/2007/08/dataservices/metadata'}
-tree = ET.parse('/tmp/psgallery.xml')
-for entry in tree.findall('.//a:entry', ns):
-    props = entry.find('.//m:properties', ns)
-    if props is None: continue
-    ver = props.find('d:Version', ns)
-    vdl = props.find('d:VersionDownloadCount', ns)
-    tdl = props.find('d:DownloadCount', ns)
-    ilv = props.find('d:IsLatestVersion', ns)
-    if ver is not None:
-        print(f'${TODAY},{ver.text},{vdl.text if vdl is not None else 0},{tdl.text if tdl is not None else 0},{ilv.text if ilv is not None else \"false\"}')
-" >> /tmp/psgallery_existing.csv
+          import xml.etree.ElementTree as ET, sys
+          ns = {'a': 'http://www.w3.org/2005/Atom', 'd': 'http://schemas.microsoft.com/ado/2007/08/dataservices', 'm': 'http://schemas.microsoft.com/ado/2007/08/dataservices/metadata'}
+          tree = ET.parse('/tmp/psgallery.xml')
+          today = sys.argv[1]
+          for entry in tree.findall('.//a:entry', ns):
+              props = entry.find('.//m:properties', ns)
+              if props is None: continue
+              ver = props.find('d:Version', ns)
+              vdl = props.find('d:VersionDownloadCount', ns)
+              tdl = props.find('d:DownloadCount', ns)
+              ilv = props.find('d:IsLatestVersion', ns)
+              if ver is not None:
+                  print(f'{today},{ver.text},{vdl.text if vdl is not None else 0},{tdl.text if tdl is not None else 0},{ilv.text if ilv is not None else \"false\"}')
+          " "$TODAY" >> /tmp/psgallery_existing.csv
             else
               echo "Warning: python3 not available, skipping PSGallery XML parse"
             fi


### PR DESCRIPTION
## Problem

PR #130 introduced a PSGallery XML parsing section using inline Python inside a `run: |` block. The Python code had **zero indentation**, which terminated the YAML literal block scalar at the `import` line. GitHub Actions cannot parse the workflow file, causing:

- All 3 push-triggered runs since merge to fail with *'workflow file issue'*
- Scheduled cron runs to not fire (GitHub can't read triggers from broken YAML)
- `workflow_dispatch` returns HTTP 422

## Root Cause

YAML literal block scalars (`|`) require all content lines to have indentation >= the base level (10 spaces in this file). Lines at column 0 signal end-of-block, so YAML tried to parse `import xml.etree.ElementTree...` as a mapping key.

## Fix

- Indent all Python lines to 10+ spaces so they stay inside the `run: |` block
- Pass `$TODAY` via `sys.argv[1]` instead of bash variable interpolation inside the Python code
- Runtime behavior is identical

## Verification Checklist

### Verified Landmark Table

| Landmark / Claim | Evidence | Tag |
|---|---|---|
| YAML parses after fix | `python3 -c "import yaml; yaml.safe_load(...)"; print('YAML valid')` returned success | [OBSERVED] |
| Python code at column 0 after YAML strip | YAML safe_load shows `import xml.etree...` at column 0, `for` body at 4 spaces | [OBSERVED] |
| Workflow name unreadable before fix | `gh workflow list` showed raw file path instead of "Collect Traffic Data" | [OBSERVED] |
| workflow_dispatch rejected before fix | `gh workflow run` returned HTTP 422 "does not have workflow_dispatch trigger" | [OBSERVED] |
| 3 push runs failed with 'workflow file issue' | `gh run list --workflow=collect-traffic.yml` showed 3 push failures since merge | [OBSERVED] |

### Behavior Parity

- [x] No parameter changes
- [x] No output format changes
- [x] Python logic unchanged — only indentation and `$TODAY` → `sys.argv[1]`
- [x] YAML block scalar content produces identical bash script after processing

## Quality Checklist

- [x] `Validate-Script.ps1` — N/A (no PowerShell changes)
- [x] YAML validates with Python yaml.safe_load
- [x] Single file changed, 14 insertions / 13 deletions
- [x] No new features — bug fix only
