### PR TITLE
feat: pipeline capture detection UX + roadmap accuracy (v2.1.1)

### DIFF
--- a/AzVMAvailability/AzVMAvailability.psd1
+++ b/AzVMAvailability/AzVMAvailability.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule        = 'AzVMAvailability.psm1'
-    ModuleVersion     = '2.1.0'
+    ModuleVersion     = '2.1.1'
     GUID              = '7f42e8d6-e85d-4e31-a541-d9af648a5269'
     Author            = 'Zachary Luz'
     CompanyName       = 'Community'

--- a/AzVMAvailability/Public/Get-AzVMAvailability.ps1
+++ b/AzVMAvailability/Public/Get-AzVMAvailability.ps1
@@ -126,7 +126,7 @@ function Get-AzVMAvailability {
     Name:           Get-AzVMAvailability
     Author:         Zachary Luz
     Created:        2026-01-21
-    Version:        2.1.0
+    Version:        2.1.1
     License:        MIT
     Repository:     https://github.com/zacharyluz/Get-AzVMAvailability
 

--- a/AzVMAvailability/Public/Get-AzVMAvailability.ps1
+++ b/AzVMAvailability/Public/Get-AzVMAvailability.ps1
@@ -3211,9 +3211,27 @@ if ($JsonOutput) {
 
 # Emit structured objects to pipeline only when console stdout is redirected (e.g., > file.txt or Start-Transcript).
 # [Console]::IsOutputRedirected detects console-level redirection only — it does NOT detect PS pipeline usage.
-# For interactive pipeline scenarios, use -JsonOutput. A dedicated -PassThru switch is planned for v2.0.
+# For interactive pipeline scenarios, use -JsonOutput. A dedicated -PassThru switch is planned for a future version.
 if (-not $JsonOutput -and $familyDetails.Count -gt 0 -and [Console]::IsOutputRedirected) {
+    Write-Verbose "Pipeline emit: outputting $($familyDetails.Count) detail objects (stdout is redirected)"
+    Write-Verbose "  If this output is unexpected, use -JsonOutput for structured data or run without redirection for console-only display."
     $familyDetails
+}
+elseif (-not $JsonOutput -and $familyDetails.Count -gt 0 -and -not [Console]::IsOutputRedirected) {
+    # Detect common capture patterns that WON'T trigger IsOutputRedirected but users expect to capture data
+    # This runs only in interactive mode — zero overhead when redirected or using -JsonOutput
+    $callStack = Get-PSCallStack
+    $capturePatterns = $callStack | Where-Object { $_.Command -match 'Tee-Object|ForEach-Object|Select-Object|Where-Object|Out-File|Export-Csv|ConvertTo-Json' }
+    if ($capturePatterns) {
+        Write-Host ''
+        Write-Host '  TIP: Pipeline capture detected but no objects were emitted.' -ForegroundColor Yellow
+        Write-Host '  Get-AzVMAvailability outputs colored tables to the console by default.' -ForegroundColor Yellow
+        Write-Host '  To get structured data for pipeline processing, use one of:' -ForegroundColor DarkGray
+        Write-Host '    -JsonOutput              → JSON string (recommended for automation)' -ForegroundColor DarkGray
+        Write-Host '    > output.txt             → triggers automatic pipeline object emit' -ForegroundColor DarkGray
+        Write-Host '    -AutoExport -ExportPath . → CSV/XLSX file export' -ForegroundColor DarkGray
+        Write-Host ''
+    }
 }
 
 #region Drill-Down (if enabled)

--- a/AzVMAvailability/Public/Get-AzVMAvailability.ps1
+++ b/AzVMAvailability/Public/Get-AzVMAvailability.ps1
@@ -3218,19 +3218,24 @@ if (-not $JsonOutput -and $familyDetails.Count -gt 0 -and [Console]::IsOutputRed
     $familyDetails
 }
 elseif (-not $JsonOutput -and $familyDetails.Count -gt 0 -and -not [Console]::IsOutputRedirected) {
-    # Detect common capture patterns that WON'T trigger IsOutputRedirected but users expect to capture data
-    # This runs only in interactive mode — zero overhead when redirected or using -JsonOutput
-    $callStack = Get-PSCallStack
-    $capturePatterns = $callStack | Where-Object { $_.Command -match 'Tee-Object|ForEach-Object|Select-Object|Where-Object|Out-File|Export-Csv|ConvertTo-Json' }
-    if ($capturePatterns) {
-        Write-Host ''
-        Write-Host '  TIP: Pipeline capture detected but no objects were emitted.' -ForegroundColor Yellow
-        Write-Host '  Get-AzVMAvailability outputs colored tables to the console by default.' -ForegroundColor Yellow
-        Write-Host '  To get structured data for pipeline processing, use one of:' -ForegroundColor DarkGray
-        Write-Host '    -JsonOutput              → JSON string (recommended for automation)' -ForegroundColor DarkGray
-        Write-Host '    > output.txt             → triggers automatic pipeline object emit' -ForegroundColor DarkGray
-        Write-Host '    -AutoExport -ExportPath . → CSV/XLSX file export' -ForegroundColor DarkGray
-        Write-Host ''
+    # Detect common capture patterns that WON'T trigger IsOutputRedirected but users expect to capture data.
+    # Only inspect call stack when this command is actually in a pipeline (PipelineLength > 1).
+    # Show tip once per session to avoid noise on repeated runs.
+    if ($MyInvocation.PipelineLength -gt 1 -and -not $script:PipelineTipShown) {
+        $callStack = Get-PSCallStack
+        $pipelineCmdlets = @('Tee-Object', 'ForEach-Object', 'Select-Object', 'Where-Object', 'Out-File', 'Export-Csv', 'ConvertTo-Json', 'ConvertTo-Csv', 'Sort-Object', 'Group-Object', 'Measure-Object')
+        $capturePatterns = $callStack | Where-Object { $_.Command -in $pipelineCmdlets }
+        if ($capturePatterns) {
+            $script:PipelineTipShown = $true
+            Write-Host ''
+            Write-Host '  TIP: Pipeline capture detected but no objects were emitted.' -ForegroundColor Yellow
+            Write-Host '  Get-AzVMAvailability outputs colored tables to the console by default.' -ForegroundColor Yellow
+            Write-Host '  To get structured data for pipeline processing, use one of:' -ForegroundColor DarkGray
+            Write-Host '    -JsonOutput              → JSON string (recommended for automation)' -ForegroundColor DarkGray
+            Write-Host '    > output.txt             → stdout redirection; triggers automatic object emit' -ForegroundColor DarkGray
+            Write-Host '    -AutoExport -ExportPath . → CSV/XLSX file export' -ForegroundColor DarkGray
+            Write-Host ''
+        }
     }
 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.1] — 2026-04-14
+
+### Changed
+- **Pipeline capture detection** — When users pipe `Get-AzVMAvailability` output interactively (e.g., `| Select-Object SKU`) and no objects emit, a yellow TIP now appears explaining the three ways to get structured data: `-JsonOutput`, file redirection (`>`), or `-AutoExport`. Zero overhead when using `-JsonOutput` or file redirection — the call stack check only runs in interactive-no-redirect mode.
+
+### Documentation
+- **ROADMAP accuracy** — Marked v2.0.0 and v2.1.0 as Released with all shipped items checked. Corrected backlog items (Module Structure, Shared Helpers) to reference v2.0.0 shipment.
+
 ## [2.1.0] — 2026-07-17
 
 ### Added

--- a/Get-AzVMAvailability.ps1
+++ b/Get-AzVMAvailability.ps1
@@ -175,7 +175,7 @@ param(
 )
 
 # Version for Validate-Script.ps1 parity check (must match .psd1 ModuleVersion)
-$ScriptVersion = "2.1.0"
+$ScriptVersion = "2.1.1"
 Write-Verbose "Get-AzVMAvailability wrapper v$ScriptVersion"
 
 # Import the AzVMAvailability module from the same directory as this script

--- a/Get-AzVMAvailability.ps1
+++ b/Get-AzVMAvailability.ps1
@@ -16,7 +16,7 @@
     Name:           Get-AzVMAvailability
     Author:         Zachary Luz
     Created:        2026-01-21
-    Version:        2.1.0
+    Version:        2.1.1
     License:        MIT
     Repository:     https://github.com/zacharyluz/Get-AzVMAvailability
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A PowerShell tool for checking Azure VM SKU availability across regions - find w
 ![PowerShell](https://img.shields.io/badge/PowerShell-7.0%2B-blue)
 ![Azure](https://img.shields.io/badge/Azure-Az%20Modules-0078D4)
 ![License](https://img.shields.io/badge/License-MIT-green)
-![Version](https://img.shields.io/badge/Version-2.1.0-brightgreen)
+![Version](https://img.shields.io/badge/Version-2.1.1-brightgreen)
 
 ## Overview
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,8 @@
 # Roadmap
 
-## Current Release: v2.1.0
+## Current Release: v2.1.1
 
-> **v2.1.0:** PSGallery download tracking, traffic dashboard fixes, smart default regions, and documentation improvements. See [CHANGELOG.md](CHANGELOG.md) for details.
+> **v2.1.1:** Pipeline capture detection UX improvement and roadmap accuracy updates. See [CHANGELOG.md](CHANGELOG.md) for details.
 
 See [CHANGELOG.md](CHANGELOG.md) for full version history.
 
@@ -192,9 +192,9 @@ See [CHANGELOG.md](CHANGELOG.md) for full version history.
 - [x] **Agent Integration** - Shipped in v1.11.1 as Copilot skill (`.github/skills/azure-vm-availability/SKILL.md`)
 
 ### PowerShell Module Refactoring
-- [x] **Module Structure** - Partially shipped in v1.12.3: 34 functions extracted to `AzVMAvailability/` module with Private/ subdirectory layout. Full module conversion deferred to v2.0.0
-- [x] **Backward-Compatible Wrapper** - Shipped in v1.12.4: inline function fallback when module directory is absent
-- [ ] **Shared Helpers** - Enable reuse across scanner, recommender, and Agent (v2.0.0)
+- [x] **Module Structure** - Shipped in v2.0.0: full Public/Private module layout with 43 private functions
+- [x] **Backward-Compatible Wrapper** - Shipped in v2.0.0: `Get-AzVMAvailability.ps1` imports module and forwards parameters
+- [x] **Shared Helpers** - Shipped in v2.0.0: Private/ functions reusable across scanner, recommender, and Agent
 
 ### Azure Resource Graph Integration
 - [x] **Current VM Inventory** - Shipped in v1.14.0 as `-LifecycleScan`
@@ -219,14 +219,18 @@ See [CHANGELOG.md](CHANGELOG.md) for full version history.
 
 ---
 
-## Version 2.0.0 (Future)
+## Version 2.0.0 (Released)
 **Theme: Module Implementation**
 
-- [ ] **Module Structure** - Refactor into `AzVMAvailability` module with Public/Private functions
-- [ ] **Backward-Compatible Wrapper** - Keep `Get-AzVMAvailability.ps1` as entry point
-- [ ] **Shared Helpers** - Enable reuse across scanner, recommender, and Agent
-- [ ] **Module Manifest + Validation** - Add and validate `.psd1` manifest in CI
-- [ ] **Migration Guidance** - Document script-to-module migration path and examples
+- [x] **Module Structure** - Refactored into `AzVMAvailability` module with Public/Private functions (43 private, 1 public)
+- [x] **Backward-Compatible Wrapper** - `Get-AzVMAvailability.ps1` as thin wrapper that imports module and forwards `@PSBoundParameters`
+- [x] **Shared Helpers** - Private/ functions enable reuse across scanner, recommender, and Agent
+- [x] **Module Manifest + Validation** - `.psd1` manifest with Az module dependencies; CI validates module import
+- [x] **Migration Guidance** - Script vs Module comparison in README; identical parameters and output
+- [x] **PSGallery Publishing** - `release-publish.yml` workflow publishes to PowerShell Gallery on GitHub Release
+- [x] **Module Tests** - `tests/Module.Tests.ps1` validates import, exports, version, and private function isolation
+- [x] **Parameter Parity Tests** - `tests/ParameterParity.Tests.ps1` validates all 39 parameters
+- [x] **PR Verification Gate** - `pr-verification-gate.yml` CI gate with Verification-First checklist
 - [ ] **Pipeline Emit as Opt-In** - Add `-PassThru` switch for pipeline output; do NOT emit `$familyDetails` unconditionally (breaks terminal UX when output is captured via `*>&1` or `Tee-Object` — 223 lines → 2,478 lines). In module mode, objects become primary output with Write-Host as secondary display.
 
 ---
@@ -253,7 +257,18 @@ See [CHANGELOG.md](CHANGELOG.md) for full version history.
 
 ---
 
-## Version 2.1.0 (Future)
+## Version 2.1.0 (Released)
+**Theme: Smart Defaults & Documentation**
+
+### Shipped Features
+- [x] **Smart Default Regions** — Auto-detect default regions based on cloud environment and user timezone
+- [x] **PSGallery Download Tracking** — Traffic collector now fetches PSGallery total download counts
+- [x] **README Split** — README is now a concise landing page linking to 11 topic guides under `docs/`
+- [x] **Traffic Dashboard Fixes** — Fixed off-by-one date filtering and delta display for N/A periods
+
+---
+
+## Version 2.2.0 (Future)
 **Theme: MCP Server Interface** ([#28](https://github.com/ZacharyLuz/Get-AzVMAvailability/issues/28))
 
 Expose VM availability data as MCP tools so AI coding agents (Copilot, Claude, etc.) can pre-validate SKU selection during Terraform/Bicep authoring — before deployment fails.

--- a/demo/DEMO-GUIDE.md
+++ b/demo/DEMO-GUIDE.md
@@ -1,6 +1,6 @@
 # Get-AzVMAvailability — Live Demo Guide
 
-**Version:** 2.1.0 | **Duration:** ~40 minutes + Q&A | **Audience:** Internal Microsoft / External Customers
+**Version:** 2.1.1 | **Duration:** ~40 minutes + Q&A | **Audience:** Internal Microsoft / External Customers
 
 ---
 


### PR DESCRIPTION
## Summary

Pipeline capture detection UX improvement + roadmap accuracy corrections. Version bump to v2.1.1.

## Changes

### Pipeline Capture Detection (UX Improvement)
- When users pipe `Get-AzVMAvailability` output interactively (e.g., `| Select-Object SKU`) and no objects emit, a yellow TIP now appears explaining the three ways to get structured data:
  - `-JsonOutput` (recommended for automation)
  - File redirection (`>`) which triggers automatic pipeline object emit
  - `-AutoExport` for CSV/XLSX file export
- Uses `Get-PSCallStack` to detect pipeline cmdlets (`Tee-Object`, `Select-Object`, `Where-Object`, etc.)
- Zero overhead when using `-JsonOutput` or file redirection — the call stack check only runs in interactive-no-redirect mode

### Roadmap Accuracy
- Marked v2.0.0 as Released with all 9 shipped items checked
- Marked v2.1.0 as Released with 4 shipped items checked
- Corrected backlog items: Module Structure, Shared Helpers, Backward-Compatible Wrapper now reference v2.0.0 shipment
- Renumbered future MCP Server version from 2.1.0 to 2.2.0

### Version Bump
- v2.1.0 → v2.1.1 across .psd1, wrapper .NOTES, public function .NOTES, wrapper `$ScriptVersion`, ROADMAP, CHANGELOG

## Verification Checklist

### Verified Landmark Table

| Landmark / Claim | Evidence | Tag |
|---|---|---|
| Pipeline capture detection logic added at line ~3215 | Read `Get-AzVMAvailability.ps1` — `Get-PSCallStack` + `Write-Host` TIP block present | [OBSERVED] |
| `IsOutputRedirected` guard unchanged | Original guard at line 3215 still emits `$familyDetails` when redirected | [OBSERVED] |
| .psd1 ModuleVersion = 2.1.1 | `Import-PowerShellDataFile` shows `ModuleVersion = '2.1.1'` | [OBSERVED] |
| Wrapper `$ScriptVersion` = 2.1.1 | Line 178 in `Get-AzVMAvailability.ps1` | [OBSERVED] |
| .NOTES Version = 2.1.1 in wrapper | Line 19 in `Get-AzVMAvailability.ps1` | [OBSERVED] |
| .NOTES Version = 2.1.1 in public function | Line 129 in public function | [OBSERVED] |
| CHANGELOG has `## [2.1.1]` heading | First entry in CHANGELOG.md | [OBSERVED] |
| ROADMAP shows v2.1.1 as current | Line 3 of ROADMAP.md | [OBSERVED] |
| v2.0.0 marked Released in ROADMAP | Section header says "(Released)" with 9 [x] items | [OBSERVED] |
| v2.1.0 marked Released in ROADMAP | Section header says "(Released)" with 4 [x] items | [OBSERVED] |
| Zero PSScriptAnalyzer warnings | Ran with repo settings, no output | [OBSERVED] |

### Behavior Parity
- No parameter changes (still 39 parameters, same names/types/defaults)
- `IsOutputRedirected` pipeline emit guard behavior unchanged
- `-JsonOutput` output contract unchanged
- New `elseif` branch only executes in interactive mode when `IsOutputRedirected` is false
- Write-Host TIP is informational only — does not affect pipeline or return values

## Quality Checklist
- [x] `tools/Validate-Script.ps1` checks verified (syntax + lint)
- [x] No new parameters added
- [x] No output contract changes
- [x] CHANGELOG updated
- [x] ROADMAP updated
- [x] Version parity across all 5 locations
- [x] Release/tag plan prepared for this version bump
