### PR TITLE
fix: deduplicate release labels and increase stagger capacity

### DIFF
--- a/tools/dashboard.js
+++ b/tools/dashboard.js
@@ -71,7 +71,7 @@ function lineOpts(legend) {
 }
 
 // Layout constant — shared across all charts that show release annotations
-var RELEASE_LABEL_PADDING = 40;
+var RELEASE_LABEL_PADDING = 56;
 
 // ── Shared release annotation plugin builder ──
 // Returns a Chart.js plugin that draws vertical dashed lines at release dates.
@@ -87,6 +87,23 @@ function makeReleasePlugin(releases, filteredDatesRef) {
         .map(function(r) { return { version: r.version, date: r.date, idx: dates.indexOf(r.date) }; })
         .sort(function(a, b) { return a.idx - b.idx; });
       if (!visible.length) return;
+      // Deduplicate: keep only the highest version per chart date
+      var deduped = {};
+      visible.forEach(function(r) {
+        var key = r.idx;
+        if (!(key in deduped)) {
+          deduped[key] = r;
+        } else {
+          var cur = deduped[key].version.replace(/^v/, '').split('.').map(Number);
+          var cand = r.version.replace(/^v/, '').split('.').map(Number);
+          for (var i = 0; i < 3; i++) {
+            if ((cand[i] || 0) > (cur[i] || 0)) { deduped[key] = r; break; }
+            if ((cand[i] || 0) < (cur[i] || 0)) break;
+          }
+        }
+      });
+      visible = Object.keys(deduped).map(function(k) { return deduped[k]; })
+        .sort(function(a, b) { return a.idx - b.idx; });
       var ctx = chart.ctx;
       var xAxis = chart.scales.x;
       var yAxis = chart.scales.y;
@@ -94,7 +111,7 @@ function makeReleasePlugin(releases, filteredDatesRef) {
       ctx.font = '10px Inter, sans-serif';
       // Measure label widths and assign stagger tiers to avoid overlap
       var minGap = 8; // px padding between labels
-      var tierSpacing = 12; // vertical px between stagger tiers
+      var tierSpacing = 14; // vertical px between stagger tiers
       var topPad = (chart.options.layout && chart.options.layout.padding) ? chart.options.layout.padding.top : RELEASE_LABEL_PADDING;
       var maxTiers = Math.max(1, Math.floor(topPad / tierSpacing));
       var placed = []; // {left, right, tier}


### PR DESCRIPTION
## Problem

Release version labels on the traffic dashboard charts overlap when multiple releases share the same date or fall on adjacent dates. The stagger algorithm from PR #134 worked but had only 3 vertical tiers, which was insufficient for clusters of 4+ releases (e.g., Jan 27 had v1.1.1 through v1.4.0).

## Fix

1. **Deduplicate same-date releases** — when multiple releases map to the same chart date index, keep only the highest semver version. Reduces ~32 labels to ~20.
2. **Increase vertical capacity** — `RELEASE_LABEL_PADDING` from 40→56 and `tierSpacing` from 12→14, yielding 4 stagger tiers instead of 3.

## Verified

Local test with production traffic data confirms clean, non-overlapping labels across all four charts (Views, Clones, Stars, PSGallery).

## Summary by Sourcery

Improve release annotation rendering on traffic dashboard charts to reduce label overlap and support more staggered tiers.

New Features:
- Deduplicate release annotations so only the highest version per chart date is labeled.

Enhancements:
- Increase available vertical padding and tier spacing for release labels to allow more stagger tiers and reduce collisions.