### PR TITLE
chore: add cross-repo traffic infrastructure sync

### DIFF
--- a/.github/workflows/sync-traffic-infra.yml
+++ b/.github/workflows/sync-traffic-infra.yml
@@ -1,0 +1,114 @@
+name: Sync Traffic Infrastructure
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'tools/dashboard.js'
+      - 'tools/Generate-TrafficDashboard-Premium-v2.ps1'
+      - '.github/workflows/collect-traffic.yml'
+  workflow_dispatch:  # manual trigger for catch-up syncs
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - repo: ZacharyLuz/Get-AzAIModelAvailability
+            repoName: Get-AzAIModelAvailability
+            psGalleryId: Get-AzAIModelAvailability
+          - repo: ZacharyLuz/Get-AzPaaSAvailability
+            repoName: Get-AzPaaSAvailability
+            psGalleryId: Get-AzPaaSAvailability
+    steps:
+      - name: Checkout source repo
+        uses: actions/checkout@v4
+
+      - name: Checkout target repo
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ matrix.target.repo }}
+          token: ${{ secrets.TRAFFIC_SYNC_TOKEN }}
+          path: target
+          fetch-depth: 1
+
+      - name: Sync files with repo-specific substitutions
+        shell: bash
+        run: |
+          SOURCE_REPO_NAME="Get-AzVMAvailability"
+          SOURCE_PSGALLERY_ID="AzVMAvailability"
+          TARGET_REPO_NAME="${{ matrix.target.repoName }}"
+          TARGET_PSGALLERY_ID="${{ matrix.target.psGalleryId }}"
+
+          changed=0
+
+          # 1. dashboard.js — straight copy (no substitutions)
+          if ! diff -q tools/dashboard.js target/tools/dashboard.js >/dev/null 2>&1; then
+            cp tools/dashboard.js target/tools/dashboard.js
+            echo "Updated: tools/dashboard.js"
+            changed=1
+          else
+            echo "In sync: tools/dashboard.js"
+          fi
+
+          # 2. collect-traffic.yml — PSGallery ID substitution
+          sed "s/id='${SOURCE_PSGALLERY_ID}'/id='${TARGET_PSGALLERY_ID}'/g" \
+            .github/workflows/collect-traffic.yml > /tmp/collect-traffic.yml
+          if ! diff -q /tmp/collect-traffic.yml target/.github/workflows/collect-traffic.yml >/dev/null 2>&1; then
+            cp /tmp/collect-traffic.yml target/.github/workflows/collect-traffic.yml
+            echo "Updated: .github/workflows/collect-traffic.yml"
+            changed=1
+          else
+            echo "In sync: .github/workflows/collect-traffic.yml"
+          fi
+
+          # 3. Generate-TrafficDashboard-Premium-v2.ps1 — repo name substitution
+          sed "s/${SOURCE_REPO_NAME}/${TARGET_REPO_NAME}/g" \
+            tools/Generate-TrafficDashboard-Premium-v2.ps1 > /tmp/dashboard-gen.ps1
+          if ! diff -q /tmp/dashboard-gen.ps1 target/tools/Generate-TrafficDashboard-Premium-v2.ps1 >/dev/null 2>&1; then
+            cp /tmp/dashboard-gen.ps1 target/tools/Generate-TrafficDashboard-Premium-v2.ps1
+            echo "Updated: tools/Generate-TrafficDashboard-Premium-v2.ps1"
+            changed=1
+          else
+            echo "In sync: tools/Generate-TrafficDashboard-Premium-v2.ps1"
+          fi
+
+          echo "changed=$changed" >> "$GITHUB_ENV"
+
+      - name: Create PR if files changed
+        if: env.changed == '1'
+        working-directory: target
+        env:
+          GH_TOKEN: ${{ secrets.TRAFFIC_SYNC_TOKEN }}
+        run: |
+          BRANCH="chore/sync-traffic-infra"
+          COMMIT_SHA="${{ github.sha }}"
+          SHORT_SHA="${COMMIT_SHA:0:7}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Clean up stale sync branch if it exists
+          git push origin --delete "$BRANCH" 2>/dev/null || true
+          git checkout -b "$BRANCH"
+          git add tools/dashboard.js .github/workflows/collect-traffic.yml tools/Generate-TrafficDashboard-Premium-v2.ps1
+          git commit -m "chore: sync traffic infrastructure from Get-AzVMAvailability ($SHORT_SHA)"
+          git push origin "$BRANCH"
+
+          gh pr create \
+            --repo "${{ matrix.target.repo }}" \
+            --base main \
+            --head "$BRANCH" \
+            --title "chore: sync traffic infrastructure from Get-AzVMAvailability" \
+            --body "Auto-synced traffic collection files from [Get-AzVMAvailability@\`$SHORT_SHA\`](https://github.com/ZacharyLuz/Get-AzVMAvailability/commit/$COMMIT_SHA).
+
+          ### Files synced
+          - \`tools/dashboard.js\`
+          - \`.github/workflows/collect-traffic.yml\`
+          - \`tools/Generate-TrafficDashboard-Premium-v2.ps1\`
+
+          Triggered by: https://github.com/ZacharyLuz/Get-AzVMAvailability/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/sync-traffic-infra.yml
+++ b/.github/workflows/sync-traffic-infra.yml
@@ -55,8 +55,9 @@ jobs:
             echo "In sync: tools/dashboard.js"
           fi
 
-          # 2. collect-traffic.yml — PSGallery ID substitution
-          sed "s/id='${SOURCE_PSGALLERY_ID}'/id='${TARGET_PSGALLERY_ID}'/g" \
+          # 2. collect-traffic.yml — repo name + PSGallery ID substitution
+          sed -e "s/${SOURCE_REPO_NAME}/${TARGET_REPO_NAME}/g" \
+              -e "s/id='${SOURCE_PSGALLERY_ID}'/id='${TARGET_PSGALLERY_ID}'/g" \
             .github/workflows/collect-traffic.yml > /tmp/collect-traffic.yml
           if ! diff -q /tmp/collect-traffic.yml target/.github/workflows/collect-traffic.yml >/dev/null 2>&1; then
             cp /tmp/collect-traffic.yml target/.github/workflows/collect-traffic.yml
@@ -66,8 +67,9 @@ jobs:
             echo "In sync: .github/workflows/collect-traffic.yml"
           fi
 
-          # 3. Generate-TrafficDashboard-Premium-v2.ps1 — repo name substitution
-          sed "s/${SOURCE_REPO_NAME}/${TARGET_REPO_NAME}/g" \
+          # 3. Generate-TrafficDashboard-Premium-v2.ps1 — repo name + PSGallery ID substitution
+          sed -e "s/${SOURCE_REPO_NAME}/${TARGET_REPO_NAME}/g" \
+              -e "s/id='${SOURCE_PSGALLERY_ID}'/id='${TARGET_PSGALLERY_ID}'/g" \
             tools/Generate-TrafficDashboard-Premium-v2.ps1 > /tmp/dashboard-gen.ps1
           if ! diff -q /tmp/dashboard-gen.ps1 target/tools/Generate-TrafficDashboard-Premium-v2.ps1 >/dev/null 2>&1; then
             cp /tmp/dashboard-gen.ps1 target/tools/Generate-TrafficDashboard-Premium-v2.ps1

--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,6 @@ fix-review-log.ps1
 
 # AI session replay logs
 .specstory/
+
+# Local TODO review files (not project docs)
+TODO-*.md

--- a/tools/Sync-TrafficInfra.ps1
+++ b/tools/Sync-TrafficInfra.ps1
@@ -1,0 +1,126 @@
+<#
+.SYNOPSIS
+    Syncs traffic collection infrastructure from this repo (source of truth) to sibling repos.
+
+.DESCRIPTION
+    Copies dashboard.js, collect-traffic.yml, and Generate-TrafficDashboard-Premium-v2.ps1
+    to Get-AzAIModelAvailability and Get-AzPaaSAvailability with correct per-repo name
+    substitutions. Run from the Get-AzVMAvailability repo root.
+
+.PARAMETER DryRun
+    Show what would change without writing files.
+
+.EXAMPLE
+    .\tools\Sync-TrafficInfra.ps1
+    .\tools\Sync-TrafficInfra.ps1 -DryRun
+#>
+
+[CmdletBinding()]
+param(
+    [switch]$DryRun
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+#region Configuration
+$SourceRepo = Split-Path $PSScriptRoot -Parent
+$SiblingRoot = Split-Path $SourceRepo -Parent
+
+# Source of truth identifiers (used in replacement patterns)
+$SourceRepoName = 'Get-AzVMAvailability'
+$SourcePSGalleryId = 'AzVMAvailability'
+
+# Target repos with their specific identifiers
+$Targets = @(
+    @{
+        Path         = Join-Path $SiblingRoot 'Get-AzAIModelAvailability'
+        RepoName     = 'Get-AzAIModelAvailability'
+        PSGalleryId  = 'Get-AzAIModelAvailability'
+    }
+    @{
+        Path         = Join-Path $SiblingRoot 'Get-AzPaaSAvailability'
+        RepoName     = 'Get-AzPaaSAvailability'
+        PSGalleryId  = 'Get-AzPaaSAvailability'
+    }
+    @{
+        Path         = Join-Path $SiblingRoot 'copilot-chat-exporter'
+        RepoName     = 'github-copilot-chat-exporter'
+        PSGalleryId  = 'github-copilot-chat-exporter'
+    }
+)
+
+# Files to sync (relative paths + whether they need name substitution)
+$SyncFiles = @(
+    @{ RelPath = 'tools/dashboard.js';                                   NeedsSub = $false }
+    @{ RelPath = '.github/workflows/collect-traffic.yml';                NeedsSub = $true  }
+    @{ RelPath = 'tools/Generate-TrafficDashboard-Premium-v2.ps1';      NeedsSub = $true  }
+)
+#endregion
+
+#region Sync Logic
+$totalChanged = 0
+$totalSkipped = 0
+
+foreach ($target in $Targets) {
+    $targetName = $target.RepoName
+    if (-not (Test-Path $target.Path)) {
+        Write-Host "  SKIP $targetName — repo not found at $($target.Path)" -ForegroundColor Yellow
+        continue
+    }
+    Write-Host "`n=== $targetName ===" -ForegroundColor Cyan
+
+    foreach ($file in $SyncFiles) {
+        $srcFile = Join-Path $SourceRepo ($file.RelPath -replace '/', [IO.Path]::DirectorySeparatorChar)
+        $dstFile = Join-Path $target.Path ($file.RelPath -replace '/', [IO.Path]::DirectorySeparatorChar)
+        $shortName = $file.RelPath
+
+        if (-not (Test-Path $srcFile)) {
+            Write-Host "  SKIP $shortName — source not found" -ForegroundColor Yellow
+            continue
+        }
+
+        $content = Get-Content $srcFile -Raw
+
+        if ($file.NeedsSub) {
+            # Replace repo-specific strings: repo name first, then PSGallery ID
+            $content = $content -replace [regex]::Escape($SourceRepoName), $target.RepoName
+            $content = $content -replace "id='$([regex]::Escape($SourcePSGalleryId))'", "id='$($target.PSGalleryId)'"
+        }
+
+        # Compare with existing target
+        $changed = $true
+        if (Test-Path $dstFile) {
+            $existing = Get-Content $dstFile -Raw
+            if ($content -eq $existing) {
+                $changed = $false
+            }
+        }
+
+        if ($changed) {
+            if ($DryRun) {
+                Write-Host "  WOULD UPDATE $shortName" -ForegroundColor Yellow
+            } else {
+                # Ensure target directory exists
+                $dstDir = Split-Path $dstFile -Parent
+                if (-not (Test-Path $dstDir)) { New-Item -ItemType Directory -Path $dstDir -Force | Out-Null }
+                $content | Set-Content -Path $dstFile -NoNewline -Encoding UTF8
+                Write-Host "  UPDATED $shortName" -ForegroundColor Green
+            }
+            $totalChanged++
+        } else {
+            Write-Host "  OK      $shortName (already in sync)" -ForegroundColor DarkGray
+            $totalSkipped++
+        }
+    }
+}
+#endregion
+
+#region Summary
+Write-Host "`n--- Summary ---" -ForegroundColor White
+if ($DryRun) {
+    Write-Host "DRY RUN: $totalChanged file(s) would be updated, $totalSkipped already in sync" -ForegroundColor Yellow
+} else {
+    Write-Host "$totalChanged file(s) updated, $totalSkipped already in sync" -ForegroundColor Green
+}
+#endregion


### PR DESCRIPTION
Adds Sync-TrafficInfra.ps1 (local) and sync-traffic-infra.yml (GitHub Actions) to automatically propagate traffic collection changes to AI, PaaS, and copilot-chat-exporter repos. Also adds TODO-*.md to .gitignore for local review files.

## Summary by Sourcery

Add automation to sync traffic collection infrastructure files from this repository to sibling repositories and keep local review notes out of version control.

New Features:
- Introduce a Sync-TrafficInfra.ps1 script to propagate traffic collection files to AI, PaaS, and copilot-chat-exporter repositories with optional dry-run support.
- Add a GitHub Actions workflow to automatically sync traffic infrastructure to sibling repositories on relevant changes or manual trigger.

Build:
- Update .gitignore to exclude local TODO review markdown files from version control.