### PR TITLE
chore(ci): matrix Pester, Dependabot, CODEOWNERS, ruleset, version-bump workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,27 @@
+# CODEOWNERS — auto-requests review from the listed owners when matched paths change.
+# Path matching rules: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-security/customizing-your-repository/about-code-owners
+#
+# Last matching pattern wins. Keep broad defaults first, then narrow overrides below.
+
+# Default: anything not matched by a more specific rule.
+* @ZacharyLuz
+
+# Module source — the behavioral core. Any change here affects parity guarantees.
+/AzVMAvailability/ @ZacharyLuz
+
+# Thin wrapper script — backward-compat entry point. Changes here are high-blast-radius.
+/Get-AzVMAvailability.ps1 @ZacharyLuz
+
+# CI/CD, release, and policy — changes here can weaken guardrails if misconfigured.
+/.github/ @ZacharyLuz
+/.github/workflows/ @ZacharyLuz
+/tools/ @ZacharyLuz
+
+# Tests — review ensures coverage doesn't quietly shrink.
+/tests/ @ZacharyLuz
+
+# Release + metadata artifacts that the release-metadata-guard workflow enforces.
+/CHANGELOG.md @ZacharyLuz
+/AzVMAvailability/AzVMAvailability.psd1 @ZacharyLuz
+/README.md @ZacharyLuz
+/ROADMAP.md @ZacharyLuz

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+
+# Dependabot keeps GitHub Actions and any future package manifests up to date.
+# PowerShell Gallery modules (Az.*, Pester, PSScriptAnalyzer) are NOT managed
+# by Dependabot — those are pinned inside workflow `Install-Module` calls and
+# get updated by hand when minimum-version bumps are intentional.
+
+updates:
+  # Keep all workflow action versions (actions/checkout, actions/github-script,
+  # microsoft/psscriptanalyzer-action, etc.) current.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    groups:
+      # Group patch + minor bumps of actions together so reviewers see
+      # one PR per week, not ten.
+      actions-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/rulesets/main-branch.json
+++ b/.github/rulesets/main-branch.json
@@ -1,0 +1,93 @@
+{
+    "name": "Protect_Main_Branch",
+    "target": "branch",
+    "enforcement": "active",
+    "conditions": {
+        "ref_name": {
+            "exclude": [],
+            "include": [
+                "refs/heads/main",
+                "refs/heads/master"
+            ]
+        }
+    },
+    "rules": [
+        {
+            "type": "deletion"
+        },
+        {
+            "type": "non_fast_forward"
+        },
+        {
+            "type": "required_linear_history"
+        },
+        {
+            "type": "pull_request",
+            "parameters": {
+                "required_approving_review_count": 0,
+                "dismiss_stale_reviews_on_push": false,
+                "required_reviewers": [],
+                "require_code_owner_review": true,
+                "require_last_push_approval": false,
+                "required_review_thread_resolution": true,
+                "allowed_merge_methods": [
+                    "squash",
+                    "rebase"
+                ]
+            }
+        },
+        {
+            "type": "required_status_checks",
+            "parameters": {
+                "strict_required_status_checks_policy": true,
+                "do_not_enforce_on_create": false,
+                "required_status_checks": [
+                    {
+                        "context": "PSScriptAnalyzer"
+                    },
+                    {
+                        "context": "Pester Tests (ubuntu-latest)"
+                    },
+                    {
+                        "context": "Pester Tests (windows-latest)"
+                    },
+                    {
+                        "context": "Repo Self-Audit"
+                    },
+                    {
+                        "context": "Verification-First Checklist Present"
+                    },
+                    {
+                        "context": "Release Metadata Guard"
+                    }
+                ]
+            }
+        },
+        {
+            "type": "copilot_code_review",
+            "parameters": {
+                "review_on_push": true,
+                "review_draft_pull_requests": true
+            }
+        },
+        {
+            "type": "code_scanning",
+            "parameters": {
+                "code_scanning_tools": [
+                    {
+                        "tool": "CodeQL",
+                        "security_alerts_threshold": "high_or_higher",
+                        "alerts_threshold": "all"
+                    }
+                ]
+            }
+        }
+    ],
+    "bypass_actors": [
+        {
+            "actor_id": 5,
+            "actor_type": "RepositoryRole",
+            "bypass_mode": "pull_request"
+        }
+    ]
+}

--- a/.github/workflows/powershell-lint.yml
+++ b/.github/workflows/powershell-lint.yml
@@ -34,8 +34,12 @@ jobs:
               if: always()
 
     test:
-        name: Pester Tests
-        runs-on: ubuntu-latest
+        name: Pester Tests (${{ matrix.os }})
+        runs-on: ${{ matrix.os }}
+        strategy:
+            fail-fast: false
+            matrix:
+                os: [ubuntu-latest, windows-latest]
         steps:
             - name: Checkout repository
               uses: actions/checkout@v4.2.2
@@ -53,12 +57,42 @@ jobs:
               shell: pwsh
               run: |
                   $unitTests = Get-ChildItem ./tests/*.Tests.ps1 | Where-Object Name -ne 'Integration.Tests.ps1'
-                  $results = Invoke-Pester -Path $unitTests.FullName -Output Detailed -PassThru
+                  $config = New-PesterConfiguration
+                  $config.Run.Path = $unitTests.FullName
+                  $config.Run.PassThru = $true
+                  $config.Output.Verbosity = 'Detailed'
+                  $config.TestResult.Enabled = $true
+                  $config.TestResult.OutputFormat = 'NUnitXml'
+                  $config.TestResult.OutputPath = "./artifacts/pester-${{ matrix.os }}.xml"
+                  $config.CodeCoverage.Enabled = $true
+                  $config.CodeCoverage.Path = @(
+                      './AzVMAvailability/Public/*.ps1',
+                      './AzVMAvailability/Private/**/*.ps1'
+                  )
+                  $config.CodeCoverage.OutputFormat = 'JaCoCo'
+                  $config.CodeCoverage.OutputPath = "./artifacts/coverage-${{ matrix.os }}.xml"
+                  New-Item -ItemType Directory -Force -Path ./artifacts | Out-Null
+                  $results = Invoke-Pester -Configuration $config
                   if ($results.FailedCount -gt 0) {
                     throw "$($results.FailedCount) test(s) failed"
                   }
 
+            - name: Upload test results
+              if: always()
+              uses: actions/upload-artifact@v4
+              with:
+                  name: pester-results-${{ matrix.os }}
+                  path: ./artifacts/pester-${{ matrix.os }}.xml
+
+            - name: Upload coverage
+              if: always()
+              uses: actions/upload-artifact@v4
+              with:
+                  name: coverage-${{ matrix.os }}
+                  path: ./artifacts/coverage-${{ matrix.os }}.xml
+
             - name: Upload module artifact
+              if: matrix.os == 'ubuntu-latest'
               uses: actions/upload-artifact@v4
               with:
                   name: AzVMAvailability-module

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -125,9 +125,9 @@ jobs:
               $updated = [regex]::Replace($text, $t.Pattern, $replacement, 1)
               if ($updated -eq $text) { throw "Replacement made no change in $($t.Path)" }
               $hadTrailingNewline = $text.EndsWith("`n")
-              Set-Content -Path $t.Path -Value $updated -NoNewline
+              Set-Content -Path $t.Path -Value $updated -NoNewline -Encoding utf8
               if ($hadTrailingNewline -and -not $updated.EndsWith("`n")) {
-                  Add-Content -Path $t.Path -Value ''
+                  Add-Content -Path $t.Path -Value '' -Encoding utf8
               }
           }
 
@@ -151,12 +151,15 @@ jobs:
           $stub = ($stubLines -join "`n")
 
           $anchorMatch = [regex]::Match($changelog, '(?m)^## \[')
-          if (-not $anchorMatch.Success) { throw "No existing release header in CHANGELOG.md" }
-          $newChangelog = $changelog.Substring(0, $anchorMatch.Index) + $stub + $changelog.Substring($anchorMatch.Index)
+          if ($anchorMatch.Success) {
+              $newChangelog = $changelog.Substring(0, $anchorMatch.Index) + $stub + $changelog.Substring($anchorMatch.Index)
+          } else {
+              $newChangelog = $stub + $changelog
+          }
           $hadTrailingNewline = $changelog.EndsWith("`n")
-          Set-Content -Path $changelogPath -Value $newChangelog -NoNewline
+          Set-Content -Path $changelogPath -Value $newChangelog -NoNewline -Encoding utf8
           if ($hadTrailingNewline -and -not $newChangelog.EndsWith("`n")) {
-              Add-Content -Path $changelogPath -Value ''
+              Add-Content -Path $changelogPath -Value '' -Encoding utf8
           }
 
           "current_version=$currentVersion" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
@@ -177,18 +180,27 @@ jobs:
         run: |
           $ErrorActionPreference = 'Stop'
 
+          function Invoke-Git {
+              param(
+                  [Parameter(ValueFromRemainingArguments = $true)]
+                  [string[]] $Arguments
+              )
+              & git @Arguments
+              if ($LASTEXITCODE -ne 0) { throw "git $($Arguments -join ' ') failed with exit code $LASTEXITCODE" }
+          }
+
           $branch = "chore/version-bump-$($env:NEW_VERSION)"
 
-          git config user.name  'github-actions[bot]'
-          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git checkout -b $branch
+          Invoke-Git config user.name  'github-actions[bot]'
+          Invoke-Git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          Invoke-Git checkout -b $branch
 
-          git add Get-AzVMAvailability.ps1 `
+          Invoke-Git add Get-AzVMAvailability.ps1 `
                   AzVMAvailability/AzVMAvailability.psd1 `
                   AzVMAvailability/Public/Get-AzVMAvailability.ps1 `
                   CHANGELOG.md
-          git commit -m "chore: bump version $($env:CURRENT_VERSION) -> $($env:NEW_VERSION) ($($env:BUMP_TYPE))"
-          git push -u origin $branch
+          Invoke-Git commit -m "chore: bump version $($env:CURRENT_VERSION) -> $($env:NEW_VERSION) ($($env:BUMP_TYPE))"
+          Invoke-Git push -u origin $branch
 
           $landmarks = $env:LANDMARKS | ConvertFrom-Json
           $tableRows = foreach ($l in $landmarks) {

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,285 @@
+name: "Version Bump"
+
+# Deterministic version-bump helper.
+# Updates the four authoritative version strings atomically, prepends a CHANGELOG
+# stub, opens a PR with a pre-populated Verification Checklist (including the
+# Verified Landmark Table required by pr-verification-gate.yml).
+#
+# This workflow makes NO behavior changes to the module. Metadata-only.
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump_type:
+        description: "Semver segment to bump"
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      changelog_summary:
+        description: "One-line summary for CHANGELOG stub (leave blank to fill in PR)"
+        required: false
+        type: string
+        default: ""
+      draft_pr:
+        description: "Open PR as draft"
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: version-bump
+  cancel-in-progress: false
+
+jobs:
+  bump:
+    name: Compute, update, and open PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4.2.2
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Compute next version and update files
+        id: bump
+        env:
+          BUMP_TYPE: ${{ inputs.bump_type }}
+          CHANGELOG_SUMMARY: ${{ inputs.changelog_summary }}
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          $targets = @(
+              @{
+                  Path    = 'Get-AzVMAvailability.ps1'
+                  Pattern = '(?m)^\$ScriptVersion\s*=\s*"([^"]+)"'
+                  Format  = '$ScriptVersion = "{0}"'
+                  Label   = 'wrapper $ScriptVersion'
+              },
+              @{
+                  Path    = 'Get-AzVMAvailability.ps1'
+                  Pattern = '(?m)^(\s*Version:\s*)([0-9]+\.[0-9]+\.[0-9]+)\s*$'
+                  Format  = '    Version:        {0}'
+                  Label   = 'wrapper .NOTES Version'
+              },
+              @{
+                  Path    = 'AzVMAvailability/AzVMAvailability.psd1'
+                  Pattern = "(?m)^(\s*ModuleVersion\s*=\s*')([^']+)(')"
+                  Format  = "    ModuleVersion     = '{0}'"
+                  Label   = 'manifest ModuleVersion'
+              },
+              @{
+                  Path    = 'AzVMAvailability/Public/Get-AzVMAvailability.ps1'
+                  Pattern = '(?m)^(\s*Version:\s*)([0-9]+\.[0-9]+\.[0-9]+)\s*$'
+                  Format  = '    Version:        {0}'
+                  Label   = 'public function .NOTES Version'
+              }
+          )
+
+          $wrapperText = Get-Content $targets[0].Path -Raw
+          $firstMatch = [regex]::Match($wrapperText, $targets[0].Pattern)
+          if (-not $firstMatch.Success) {
+              throw "Could not parse ScriptVersion from $($targets[0].Path)"
+          }
+          $currentVersion = $firstMatch.Groups[1].Value
+          Write-Host "Current version: $currentVersion"
+
+          $observedLines = @()
+          foreach ($t in $targets) {
+              $text = Get-Content $t.Path -Raw
+              $m = [regex]::Match($text, $t.Pattern)
+              if (-not $m.Success) {
+                  throw "Pattern did not match in $($t.Path) for $($t.Label)"
+              }
+              $found = if ($m.Groups.Count -ge 3) { $m.Groups[2].Value } else { $m.Groups[1].Value }
+              if ($found -ne $currentVersion) {
+                  throw "Pre-bump parity failure: $($t.Label) in $($t.Path) = '$found' but wrapper = '$currentVersion'. Fix drift first."
+              }
+              $lineNumber = ($text.Substring(0, $m.Index) -split "`n").Count
+              $observedLines += @{ Path = $t.Path; Line = $lineNumber; Label = $t.Label }
+          }
+
+          $parts = $currentVersion.Split('.')
+          if ($parts.Count -ne 3) { throw "Unexpected version format: $currentVersion" }
+          $major = [int]$parts[0]; $minor = [int]$parts[1]; $patch = [int]$parts[2]
+          switch ($env:BUMP_TYPE) {
+              'major' { $major++; $minor = 0; $patch = 0 }
+              'minor' { $minor++; $patch = 0 }
+              'patch' { $patch++ }
+              default { throw "Unknown bump type: $($env:BUMP_TYPE)" }
+          }
+          $newVersion = "$major.$minor.$patch"
+          Write-Host "New version:     $newVersion"
+
+          foreach ($t in $targets) {
+              $text = Get-Content $t.Path -Raw
+              $replacement = $t.Format -f $newVersion
+              $updated = [regex]::Replace($text, $t.Pattern, $replacement, 1)
+              if ($updated -eq $text) { throw "Replacement made no change in $($t.Path)" }
+              $hadTrailingNewline = $text.EndsWith("`n")
+              Set-Content -Path $t.Path -Value $updated -NoNewline
+              if ($hadTrailingNewline -and -not $updated.EndsWith("`n")) {
+                  Add-Content -Path $t.Path -Value ''
+              }
+          }
+
+          $changelogPath = 'CHANGELOG.md'
+          $changelog = Get-Content $changelogPath -Raw
+          $date = (Get-Date -Format 'yyyy-MM-dd')
+          $summary = $env:CHANGELOG_SUMMARY
+          $summaryLine = if ([string]::IsNullOrWhiteSpace($summary)) {
+              '- _TODO: describe the change before merging._'
+          } else {
+              "- $summary"
+          }
+          $stubLines = @(
+              "## [$newVersion] - $date",
+              '',
+              '### Changed',
+              $summaryLine,
+              '',
+              ''
+          )
+          $stub = ($stubLines -join "`n")
+
+          $anchorMatch = [regex]::Match($changelog, '(?m)^## \[')
+          if (-not $anchorMatch.Success) { throw "No existing release header in CHANGELOG.md" }
+          $newChangelog = $changelog.Substring(0, $anchorMatch.Index) + $stub + $changelog.Substring($anchorMatch.Index)
+          $hadTrailingNewline = $changelog.EndsWith("`n")
+          Set-Content -Path $changelogPath -Value $newChangelog -NoNewline
+          if ($hadTrailingNewline -and -not $newChangelog.EndsWith("`n")) {
+              Add-Content -Path $changelogPath -Value ''
+          }
+
+          "current_version=$currentVersion" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "new_version=$newVersion"         | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          $landmarkJson = $observedLines | ConvertTo-Json -Compress
+          "landmarks=$landmarkJson"         | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
+      - name: Create branch, commit, and open PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CURRENT_VERSION: ${{ steps.bump.outputs.current_version }}
+          NEW_VERSION: ${{ steps.bump.outputs.new_version }}
+          LANDMARKS: ${{ steps.bump.outputs.landmarks }}
+          BUMP_TYPE: ${{ inputs.bump_type }}
+          CHANGELOG_SUMMARY: ${{ inputs.changelog_summary }}
+          DRAFT_PR: ${{ inputs.draft_pr }}
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          $branch = "chore/version-bump-$($env:NEW_VERSION)"
+
+          git config user.name  'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git checkout -b $branch
+
+          git add Get-AzVMAvailability.ps1 `
+                  AzVMAvailability/AzVMAvailability.psd1 `
+                  AzVMAvailability/Public/Get-AzVMAvailability.ps1 `
+                  CHANGELOG.md
+          git commit -m "chore: bump version $($env:CURRENT_VERSION) -> $($env:NEW_VERSION) ($($env:BUMP_TYPE))"
+          git push -u origin $branch
+
+          $landmarks = $env:LANDMARKS | ConvertFrom-Json
+          $tableRows = foreach ($l in $landmarks) {
+              "| $($l.Label) updated to $($env:NEW_VERSION) | $($l.Path) L$($l.Line) - read by workflow, regex-replaced | [OBSERVED] |"
+          }
+          $tableRows = @($tableRows) + @("| CHANGELOG stub prepended for $($env:NEW_VERSION) | CHANGELOG.md - release header inserted before prior top release | [OBSERVED] |")
+
+          $summaryDisplay = if ([string]::IsNullOrWhiteSpace($env:CHANGELOG_SUMMARY)) {
+              '_Not provided at dispatch - fill in before requesting review._'
+          } else {
+              $env:CHANGELOG_SUMMARY
+          }
+
+          $bodyLines = @(
+              '## Description',
+              '',
+              "Automated version bump from **$($env:CURRENT_VERSION)** to **$($env:NEW_VERSION)** (``$($env:BUMP_TYPE)``).",
+              '',
+              'This PR updates the four authoritative version strings and prepends a CHANGELOG stub.',
+              'No module behavior is changed. Generated by `.github/workflows/version-bump.yml`.',
+              '',
+              "**Changelog summary provided:** $summaryDisplay",
+              '',
+              '## Verification Checklist',
+              '',
+              '<!-- Populated by the version-bump workflow from files actually read. -->',
+              '',
+              '### Phase 0 - Repo Facts',
+              '- [x] Workflow read every version string before editing and confirmed pre-bump parity. **[OBSERVED]**',
+              '- [x] Entrypoint verification:',
+              '  - [x] `Get-AzVMAvailability.ps1` wrapper `$ScriptVersion` updated **[OBSERVED]**',
+              '  - [x] `AzVMAvailability.psd1` `ModuleVersion` updated **[OBSERVED]**',
+              '- [x] No line numbers were claimed without reading the file. **[OBSERVED]**',
+              '- [x] Verified Landmark Table populated below. **[OBSERVED]**',
+              '',
+              '### Verified Landmark Table',
+              '',
+              '| Landmark / Claim | Evidence (file + how verified) | Tag |',
+              '|---|---|---|'
+          )
+          $bodyLines += $tableRows
+          $bodyLines += @(
+              '',
+              '### Scope Guardrails (No Feature Creep)',
+              '- [x] No new parameters, modes, report columns, file formats, or endpoints.',
+              '- [x] No behavior change - metadata-only update.',
+              '',
+              '### Behavior Parity',
+              '- [x] No code paths modified. Parity is preserved by construction:',
+              '  - [x] Interactive default UX - unchanged',
+              '  - [x] `-NoPrompt` mode - unchanged',
+              '  - [x] `-JsonOutput` mode - unchanged',
+              '  - [x] Export paths (CSV / XLSX) - unchanged',
+              '- [x] Parity tests not re-run by this workflow; run `tools/Validate-Script.ps1` locally before merge.',
+              '',
+              '## Behavior Changes',
+              '',
+              '- None.',
+              '',
+              '## Type of Change',
+              '',
+              '- [x] Code quality (refactoring, comments, tests - no behavior change)',
+              '',
+              '## Quality Checklist',
+              '',
+              '- [x] **PR markdown renders correctly** - written via `--body-file`',
+              '- [x] **Version strings in sync** - all four authoritative locations updated atomically in one commit',
+              '- [ ] **PSScriptAnalyzer clean** - run locally before merge',
+              '- [ ] **Pester tests pass** - run locally before merge',
+              '- [ ] **Syntax valid** - `.\tools\Validate-Script.ps1` before merge',
+              '- [x] **CHANGELOG.md updated** - stub inserted; fill bullets before merge',
+              '- [x] **Release/tag plan prepared** - `release-on-main.yml` will detect drift on merge and open release PR',
+              '',
+              '## Validation',
+              '',
+              '- [ ] Run `.\tools\Validate-Script.ps1` locally - workflow does not run it',
+              '- [ ] Confirm CHANGELOG bullets describe the actual release content before requesting review'
+          )
+
+          $body = ($bodyLines -join "`n")
+          $bodyFile = Join-Path $env:RUNNER_TEMP 'pr-body.md'
+          Set-Content -Path $bodyFile -Value $body -Encoding utf8
+
+          $prArgs = @(
+              'pr', 'create',
+              '--base', 'main',
+              '--head', $branch,
+              '--title', "chore: bump version $($env:CURRENT_VERSION) -> $($env:NEW_VERSION)",
+              '--body-file', $bodyFile
+          )
+          if ($env:DRAFT_PR -eq 'true') { $prArgs += '--draft' }
+
+          gh @prArgs
+          if ($LASTEXITCODE -ne 0) { throw "gh pr create failed with exit code $LASTEXITCODE" }


### PR DESCRIPTION
## Description

Bundles four CI/governance improvements and one new workflow that have been
accumulating since the v2.1.1 release. No module code changes — pure
infrastructure and tooling.

**Changes included:**
- `powershell-lint.yml` — matrix Pester job across `ubuntu-latest` + `windows-latest` with NUnit XML and JaCoCo coverage artifacts per OS leg
- `version-bump.yml` — new `workflow_dispatch` version-bump with auto-populated Verification Checklist in the resulting PR body
- `dependabot.yml` — weekly grouped GitHub Actions dependency updates (minor+patch)
- `CODEOWNERS` — routes review requests for module, CI, tools, and docs to @ZacharyLuz
- `rulesets/main-branch.json` — native GitHub ruleset replacing top-level `Protect_Main_Branch.json`; adds CodeQL gate, code owner review, squash/rebase-only, thread resolution, and strict status checks

## Verification Checklist

### Phase 0 — Repo Facts
- [x] I inventoried repo entrypoints and structure (top-level files/folders). **[OBSERVED]**
- [x] I verified which entrypoint is authoritative for behavior parity:
  - [x] `Get-AzVMAvailability.ps1` still functions as entrypoint/wrapper **[OBSERVED]**
  - [x] Module exports include the intended public cmdlet(s) **[OBSERVED]**
- [x] I did **NOT** claim any line numbers or file lengths unless directly verified. **[OBSERVED]**
- [x] I produced/updated a Verified Landmark Table (below). **[OBSERVED]**

### Verified Landmark Table

| Landmark / Claim | Evidence (file + how verified) | Tag |
|---|---|---|
| `powershell-lint.yml` test job uses matrix strategy with `ubuntu-latest` + `windows-latest` | Read `.github/workflows/powershell-lint.yml` lines 33–100; `strategy.matrix.os` array confirmed | [OBSERVED] |
| `version-bump.yml` exists as new workflow with `workflow_dispatch` trigger | Read `.github/workflows/version-bump.yml`; trigger and inputs block confirmed | [OBSERVED] |
| `dependabot.yml` targets `github-actions` ecosystem, weekly Monday schedule | Read `.github/dependabot.yml`; `package-ecosystem`, `schedule.interval`, `schedule.day` confirmed | [OBSERVED] |
| `CODEOWNERS` default rule routes `*` to `@ZacharyLuz` | Read `.github/CODEOWNERS`; default and path rules confirmed | [OBSERVED] |
| `rulesets/main-branch.json` includes 6 required status check contexts | Read `.github/rulesets/main-branch.json`; `required_status_checks.required_status_checks` array confirmed with PSScriptAnalyzer, Pester Tests (ubuntu-latest), Pester Tests (windows-latest), Repo Self-Audit, Verification-First Checklist Present, Release Metadata Guard | [OBSERVED] |
| No module code changes — `AzVMAvailability/` files untouched | `git diff --stat origin/main..HEAD` output shows only `.github/` path changes | [OBSERVED] |

### Scope Guardrails (No Feature Creep)
- [x] No new parameters, modes, report columns, file formats, or endpoints were introduced.
- [x] Any behavior change is explicitly documented under "Behavior Changes" with justification and compatibility strategy.

### Behavior Parity
- [x] Script wrapper path produces the same user-visible behavior as before for:
  - [x] Interactive default UX
  - [x] `-NoPrompt` mode
  - [x] `-JsonOutput` mode (no Write-Host contamination)
  - [x] Export paths (CSV / XLSX where applicable)
- [x] No module code changed; parity tests unchanged and passing.

## Behavior Changes

- None — CI/tooling only. Module behavior is identical.

## Type of Change

- [x] Code quality (refactoring, comments, tests — no behavior change)

## Quality Checklist

- [x] **PR markdown renders correctly** — no literal escaped `\n` sequences in title/body
- [x] **No AI instructional comments** — workflow files contain no instructional comments
- [x] **No empty catch blocks** — no PowerShell catch blocks in changed files
- [x] **No magic numbers** — N/A (YAML/JSON only)
- [x] **Version strings in sync** — no version change in this PR
- [x] **PSScriptAnalyzer clean** — no PowerShell source files changed
- [x] **Pester tests pass** — matrix job produces results for both OS legs
- [x] **Syntax valid** — no `.ps1` module changes
- [x] **CHANGELOG.md updated** — CI-only; no functional change entry required
- [x] **New functions have Pester test coverage** — no new functions added
- [x] **Release/tag plan prepared for this version bump** — no version bump

## Validation

- [x] Ran `tools/Validate-Script.ps1` — module unchanged, all checks pass
- [x] No Azure region testing required — no module changes

## Summary by Sourcery

Improve CI, governance, and release automation infrastructure without changing module behavior.

Enhancements:
- Run Pester tests on both Ubuntu and Windows via a matrix job and emit NUnit XML plus JaCoCo coverage artifacts per OS leg.
- Introduce an automated version-bump workflow that updates all authoritative version strings, prepends a CHANGELOG stub, and opens a populated PR for review.
- Define Dependabot configuration to group and schedule weekly GitHub Actions dependency updates.
- Add CODEOWNERS and a main-branch ruleset to enforce code owner reviews, status checks, and stricter main-branch protection policies.

CI:
- Enhance the PowerShell lint/test workflow to produce structured test and coverage artifacts and only publish the module artifact from the Linux leg.

Chores:
- Establish repository ownership and automated dependency maintenance as part of ongoing project governance.