### PR TITLE
docs: add coding behavior rules to copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -39,6 +39,48 @@ If you are not 100% certain about a structural fact, you MUST say "I don't know 
 
 ---
 
+## Coding Behavior Rules
+
+### 1. Think Before Coding
+State assumptions explicitly before implementing. If uncertain, ask — do not pick silently.
+
+- If multiple valid interpretations exist, present them.
+- If a simpler approach exists, name it and push back if warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+- Surface tradeoffs rather than hiding them in implementation choices.
+
+### 2. Simplicity First
+Write the minimum code that solves the problem. Nothing speculative.
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+- Ask: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+### 3. Surgical Changes
+Touch only what the request requires. Do not clean up adjacent code.
+
+- Don't improve unrelated code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it — don't delete it.
+- When your changes make imports/variables/functions unused, remove only those orphans **your changes created**. Leave pre-existing dead code alone unless asked.
+- Every changed line should trace directly to the user's request.
+
+### 4. Goal-Driven Execution
+Define success criteria before implementing. For multi-step tasks, state a brief plan:
+
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+```
+
+Transform vague tasks into verifiable goals before starting ("fix the bug" → "write a test that reproduces it, then make it pass"). Weak criteria require constant clarification; strong criteria let you loop independently.
+
+---
+
 ## Project Goal
 
 The standalone `Get-AzVMAvailability.ps1` script has been converted into a **production-grade PowerShell module** (`AzVMAvailability/`) preserving **100% behavioral parity**.


### PR DESCRIPTION
## Summary

Adds a `## Coding Behavior Rules` section to `.github/copilot-instructions.md` with four implementation discipline rules not previously covered.

## Verification Checklist

### Verified Landmark Table

| Landmark / Claim | Evidence | Tag |
|---|---|---|
| `## Coding Behavior Rules` section inserted after Anti-Hallucination block | Read file directly after edit — section confirmed between Anti-Hallucination rules and Project Goal | [OBSERVED] |
| No prior coverage of Think Before Coding, Simplicity First, Surgical Changes, Goal-Driven Execution | grep search on entire file for: simplicity, surgical, overcomplicated, tradeoff, clarif — one match (unrelated) | [SEARCHED] |
| File has no errors after edit | get_errors tool returned no errors on copilot-instructions.md | [OBSERVED] |

### Behavior Parity

Not applicable — documentation-only change to `.github/copilot-instructions.md`. No module code, parameters, or output formats modified.

## Quality Checklist

- [x] No module code changed — documentation only
- [x] No overlap with existing Anti-Hallucination rules (those cover structural facts; these cover implementation behavior)
- [x] Rules match user-provided intent
- [x] `Validate-Script.ps1` not required — no `.ps1` files changed
## Summary

Adds a `## Coding Behavior Rules` section to `.github/copilot-instructions.md` with four implementation discipline rules that were not previously covered.

## Verification Checklist

### Verified Landmark Table

| Landmark / Claim | How verified | Evidence |
|---|---|---|
| `## Coding Behavior Rules` section inserted after Anti-Hallucination block in `.github/copilot-instructions.md` | Read file directly after edit | [OBSERVED] |
| No existing coverage of Think Before Coding, Simplicity First, Surgical Changes, or Goal-Driven Execution rules | grep search across entire file for keywords: simplicity, surgical, overcomplicated, tradeoff, clarif | [SEARCHED] |
| Section placed between Anti-Hallucination block and Project Goal section | Read file lines 1-80 and confirmed insertion point | [OBSERVED] |

### Behavior Parity

Not applicable — this is a documentation-only change to `.github/copilot-instructions.md`. No module code, parameters, or output formats were modified.

## Quality Checklist

- [x] No module code changed — documentation only
- [x] No overlap with existing Anti-Hallucination rules (those cover structural facts; these cover implementation behavior)
- [x] Rules match user-provided text exactly
- [x] `Validate-Script.ps1` not required — no `.ps1` files changed
