### PR TITLE
fix(ci): allow manual release publish retry

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -14,7 +14,11 @@ permissions:
   contents: write
 
 env:
-  RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag_name || github.event.release.tag_name }}
+  RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag_name || github.event.release.tag_name }}
+
+concurrency:
+  group: release-publish-${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag_name || github.event.release.tag_name }}
+  cancel-in-progress: false
 
 jobs:
   gate:
@@ -66,6 +70,12 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ env.RELEASE_TAG }}
+
+      - name: Verify GitHub Release exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json tagName,url >/dev/null
 
       - name: Verify manifest version matches release tag
         shell: pwsh

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -3,9 +3,18 @@ name: Release & Publish
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: "Existing release tag to publish, for example v2.2.1"
+        required: true
+        type: string
 
 permissions:
   contents: write
+
+env:
+  RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag_name || github.event.release.tag_name }}
 
 jobs:
   gate:
@@ -13,6 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ env.RELEASE_TAG }}
 
       - name: Install PowerShell modules
         shell: pwsh
@@ -53,11 +64,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ env.RELEASE_TAG }}
 
       - name: Verify manifest version matches release tag
         shell: pwsh
         run: |
-          $tag = "${{ github.event.release.tag_name }}"
+          $tag = $env:RELEASE_TAG
           $tagVersion = $tag -replace '^v', ''
           $manifest = Import-PowerShellDataFile ./AzVMAvailability/AzVMAvailability.psd1
           $manifestVersion = $manifest.ModuleVersion
@@ -69,7 +82,7 @@ jobs:
       - name: Check if version already published (idempotency guard)
         shell: pwsh
         run: |
-          $tag = "${{ github.event.release.tag_name }}"
+          $tag = $env:RELEASE_TAG
           $version = $tag -replace '^v', ''
           $existing = Find-Module -Name AzVMAvailability -RequiredVersion $version -Repository PSGallery -ErrorAction SilentlyContinue
           if ($existing) {
@@ -110,12 +123,12 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release upload "${{ github.event.release.tag_name }}" ./AzVMAvailability.zip --clobber
+          gh release upload "$RELEASE_TAG" ./AzVMAvailability.zip --clobber
 
       - name: Verify publication
         shell: pwsh
         run: |
-          $tag = "${{ github.event.release.tag_name }}"
+          $tag = $env:RELEASE_TAG
           $version = $tag -replace '^v', ''
           # Allow PSGallery indexing delay
           Start-Sleep -Seconds 30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Release publish gate** — `release-publish.yml` now blocks PSGallery publishing on PSScriptAnalyzer errors, not warnings, matching the main lint gate behavior that already reports warnings through SARIF/code scanning.
-- **Manual release publish retry** — `release-publish.yml` can now be run manually for an existing tag, so a release can be published to PSGallery without moving the tag when an older tag contains stale workflow logic.
+- **Manual release publish retry** — `release-publish.yml` can now be run manually for an existing tag, so a release can be published to PSGallery without moving the tag when an older tag contains stale workflow logic. Manual publishes now also validate that the GitHub Release exists before PSGallery publishing and serialize runs per release tag.
 
 ## [2.2.1] — 2026-04-30
 **Theme: Pricing Correctness Follow-up to v2.2.0**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Release publish gate** — `release-publish.yml` now blocks PSGallery publishing on PSScriptAnalyzer errors, not warnings, matching the main lint gate behavior that already reports warnings through SARIF/code scanning.
+- **Manual release publish retry** — `release-publish.yml` can now be run manually for an existing tag, so a release can be published to PSGallery without moving the tag when an older tag contains stale workflow logic.
 
 ## [2.2.1] — 2026-04-30
 **Theme: Pricing Correctness Follow-up to v2.2.0**

--- a/artifacts/copilot-review-log.md
+++ b/artifacts/copilot-review-log.md
@@ -1,0 +1,8 @@
+# Copilot Review Log
+
+## PR #150 — fix/release-publish-manual-dispatch
+
+- Branch: fix/release-publish-manual-dispatch
+- Reviewed head SHA: a46e275f21807e90226982662446e5cb3d8589f7
+- `.github/workflows/release-publish.yml:10` — "The new manual entry point accepts any existing tag, but the workflow never verifies that a matching GitHub Release exists before publishing to PSGallery." Assessment: **Agree**. Action: added a `gh release view "$RELEASE_TAG"` gate before packaging/publishing so missing releases fail before `Publish-Module`.
+- `.github/workflows/release-publish.yml:18` — "Adding a manual trigger creates a second way to publish the same tag, but this workflow still has no concurrency guard." Assessment: **Agree**. Action: added workflow-level concurrency keyed by release tag with `cancel-in-progress: false` so publishes for the same version do not overlap.


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` to `release-publish.yml` with a required `tag_name` input.
- Check out the selected release tag in both gate and publish jobs.
- Keep the existing `release: published` trigger intact.

## Context
Recreating the `v2.2.1` GitHub Release correctly triggers `Release & Publish`, but GitHub runs the workflow content from the `v2.2.1` tag. That tag still contains the older warning-fatal PSScriptAnalyzer gate, so the release event cannot publish even after the workflow was fixed on `main`.

This PR adds a manual retry path that runs the fixed workflow from `main` while packaging the existing tag. It does not move the `v2.2.1` tag or change the release commit.

## Verification Checklist

### Verified Landmark Table
| Landmark / Claim | Evidence | Tag |
|---|---|---|
| `release-publish.yml` currently publishes on `release: published`. | Read `.github/workflows/release-publish.yml` trigger section. | [OBSERVED] |
| Recreated `v2.2.1` release events still use the old warning-fatal gate from the tag. | Run `25237139395` failed with `Invoke-ScriptAnalyzer ... -Severity Error,Warning`; compared current `main` workflow to `v2.2.1` workflow. | [OBSERVED] |
| `PSGALLERY_API_KEY` exists in repository secrets. | Ran `gh secret list --repo ZacharyLuz/Get-AzVMAvailability` and observed `PSGALLERY_API_KEY`. | [OBSERVED] |
| This PR keeps release packaging pointed at the selected tag. | Reviewed local `git diff -- .github/workflows/release-publish.yml`. | [OBSERVED] |

### Behavior Parity
- [x] No module runtime behavior changes.
- [x] No PowerShell function, parameter, output, or manifest changes.
- [x] Existing `release: published` trigger remains.
- [x] Manual dispatch requires an explicit existing tag name.

## Quality Checklist
- [x] Scoped to `.github/workflows/release-publish.yml` and `CHANGELOG.md`.
- [x] `git diff --check` passed locally.
- [x] Release/tag plan unchanged: publish existing `v2.2.1` tag after merge via manual workflow dispatch.

## Summary by Sourcery

Allow the release publishing workflow to be manually retried for an existing tag while preserving the existing release-based trigger.

New Features:
- Add a workflow_dispatch trigger with a required tag_name input to manually run the release publishing workflow against an existing tag.

Enhancements:
- Introduce a shared RELEASE_TAG environment variable to consistently target the selected release tag across gate and publish jobs.
- Update the changelog to document the new manual release publish retry capability.