### PR TITLE
fix(ci): filter release analyzer blocking errors

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -46,9 +46,10 @@ jobs:
           $results = @()
           $results += Invoke-ScriptAnalyzer -Path ./Get-AzVMAvailability.ps1 -Settings $settings -Severity Error
           $results += Invoke-ScriptAnalyzer -Path ./AzVMAvailability -Recurse -Settings $settings -Severity Error
-          if ($results.Count -gt 0) {
-            $results | Format-Table -AutoSize
-            throw "PSScriptAnalyzer found $($results.Count) blocking error(s)"
+          $blockingResults = @($results | Where-Object Severity -eq 'Error')
+          if ($blockingResults.Count -gt 0) {
+            $blockingResults | Format-Table -AutoSize
+            throw "PSScriptAnalyzer found $($blockingResults.Count) blocking error(s)"
           }
           Write-Host "PSScriptAnalyzer: no blocking errors"
 

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -47,6 +47,11 @@ jobs:
           $results += Invoke-ScriptAnalyzer -Path ./Get-AzVMAvailability.ps1 -Settings $settings -Severity Error
           $results += Invoke-ScriptAnalyzer -Path ./AzVMAvailability -Recurse -Settings $settings -Severity Error
           $blockingResults = @($results | Where-Object Severity -eq 'Error')
+          $nonBlockingResults = @($results | Where-Object Severity -ne 'Error')
+          if ($nonBlockingResults.Count -gt 0) {
+            Write-Host "PSScriptAnalyzer returned $($nonBlockingResults.Count) non-blocking diagnostic(s):"
+            $nonBlockingResults | Format-Table -AutoSize
+          }
           if ($blockingResults.Count -gt 0) {
             $blockingResults | Format-Table -AutoSize
             throw "PSScriptAnalyzer found $($blockingResults.Count) blocking error(s)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- **Release publish gate** — `release-publish.yml` now filters PSScriptAnalyzer diagnostics to blocking errors before failing PSGallery publishing, matching the main lint gate behavior that already reports warnings through SARIF/code scanning.
+- **Release publish gate** — `release-publish.yml` now logs non-blocking PSScriptAnalyzer diagnostics but filters failures to blocking errors before stopping PSGallery publishing, matching the main lint gate behavior that already reports warnings through SARIF/code scanning.
 - **Manual release publish retry** — `release-publish.yml` can now be run manually for an existing tag, so a release can be published to PSGallery without moving the tag when an older tag contains stale workflow logic. Manual publishes now also validate that the GitHub Release exists before PSGallery publishing and serialize runs per release tag.
 
 ## [2.2.1] — 2026-04-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- **Release publish gate** — `release-publish.yml` now blocks PSGallery publishing on PSScriptAnalyzer errors, not warnings, matching the main lint gate behavior that already reports warnings through SARIF/code scanning.
+- **Release publish gate** — `release-publish.yml` now filters PSScriptAnalyzer diagnostics to blocking errors before failing PSGallery publishing, matching the main lint gate behavior that already reports warnings through SARIF/code scanning.
 - **Manual release publish retry** — `release-publish.yml` can now be run manually for an existing tag, so a release can be published to PSGallery without moving the tag when an older tag contains stale workflow logic. Manual publishes now also validate that the GitHub Release exists before PSGallery publishing and serialize runs per release tag.
 
 ## [2.2.1] — 2026-04-30

--- a/artifacts/copilot-review-log.md
+++ b/artifacts/copilot-review-log.md
@@ -6,3 +6,9 @@
 - Reviewed head SHA: a46e275f21807e90226982662446e5cb3d8589f7
 - `.github/workflows/release-publish.yml:10` — "The new manual entry point accepts any existing tag, but the workflow never verifies that a matching GitHub Release exists before publishing to PSGallery." Assessment: **Agree**. Action: added a `gh release view "$RELEASE_TAG"` gate before packaging/publishing so missing releases fail before `Publish-Module`.
 - `.github/workflows/release-publish.yml:18` — "Adding a manual trigger creates a second way to publish the same tag, but this workflow still has no concurrency guard." Assessment: **Agree**. Action: added workflow-level concurrency keyed by release tag with `cancel-in-progress: false` so publishes for the same version do not overlap.
+
+## PR #151 — fix/release-publish-filter-blocking-errors
+
+- Branch: fix/release-publish-filter-blocking-errors
+- Reviewed head SHA: a5b7862ecf9ed3a6e1d188a99971dad361eb1e70
+- `.github/workflows/release-publish.yml:54` — "The new `$blockingResults` filtering prevents warnings from blocking the gate, but it also means non-Error diagnostics returned by `Invoke-ScriptAnalyzer` are never printed to the job log." Assessment: **Agree**. Action: log non-blocking diagnostics with `Format-Table` before filtering to blocking errors.


### PR DESCRIPTION
## Summary

Fixes the release publish gate so warnings returned by PSScriptAnalyzer are not counted as blocking failures when publishing an existing release tag.

## Verification Checklist

- [x] Reproduced the failure source from the manual `Release & Publish` run log for `v2.2.1`.
- [x] Confirmed the workflow checked out `v2.2.1` and used the current manual-dispatch path.
- [x] Updated `release-publish.yml` to filter returned diagnostics to `Severity -eq 'Error'` before throwing.
- [x] Ran `git diff --check`.
- [ ] GitHub Actions PR checks pass.

### Verified Landmark Table

| Landmark / Claim | Evidence | Tag |
| --- | --- | --- |
| Release publish workflow runs the quality gate from `.github/workflows/release-publish.yml`. | Read `.github/workflows/release-publish.yml`; quality gate contains checkout, module install, PSScriptAnalyzer, and unit test steps. | [OBSERVED] |
| Manual run `25237505612` checked out tag `v2.2.1` at commit `9e62617359aa12573e0f5d04f2975cc48c75397c`. | Downloaded job log `74006714317`; checkout step showed `ref: v2.2.1` and `HEAD is now at 9e62617`. | [OBSERVED] |
| The failed gate output contained only PSScriptAnalyzer warnings but still threw `PSScriptAnalyzer found 3 blocking error(s)`. | Downloaded job log `74006714317`; analyzer table showed `Warning` severity for all returned diagnostics before the throw. | [OBSERVED] |
| The patch leaves release packaging and PSGallery publish steps unchanged. | Reviewed diff: only analyzer result filtering and changelog text changed. | [OBSERVED] |

### Behavior Parity

No module runtime behavior changes. This only changes CI/release gating behavior for PSGallery publishing: warnings remain visible in logs but only diagnostics whose returned severity is `Error` block the publish.

## Quality Checklist

- [x] Minimal workflow-only fix scoped to release publishing.
- [x] Changelog updated.
- [x] No tag movement, release deletion, or module source changes.
- [x] `git diff --check` passed locally.
