### PR TITLE
fix(ci): refresh version bump workflow coverage

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,9 +1,10 @@
 name: "Version Bump"
 
 # Deterministic version-bump helper.
-# Updates the four authoritative version strings atomically, prepends a CHANGELOG
-# stub, opens a PR with a pre-populated Verification Checklist (including the
-# Verified Landmark Table required by pr-verification-gate.yml).
+# Updates tracked version stamps atomically: four function metadata strings,
+# README badge, demo guide, ROADMAP header, and psd1 ReleaseNotes. Prepends a
+# CHANGELOG stub and opens a PR with a pre-populated Verification Checklist
+# (including the Verified Landmark Table required by pr-verification-gate.yml).
 #
 # This workflow makes NO behavior changes to the module. Metadata-only.
 
@@ -81,6 +82,24 @@ jobs:
                   Pattern = '(?m)^(\s*Version:\s*)([0-9]+\.[0-9]+\.[0-9]+)\s*$'
                   Format  = '    Version:        {0}'
                   Label   = 'public function .NOTES Version'
+              },
+              @{
+                  Path    = 'README.md'
+                  Pattern = '(?m)!\[Version\]\(https://img\.shields\.io/badge/Version-([0-9]+\.[0-9]+\.[0-9]+)-brightgreen\)'
+                  Format  = '![Version](https://img.shields.io/badge/Version-{0}-brightgreen)'
+                  Label   = 'README version badge'
+              },
+              @{
+                  Path    = 'demo/DEMO-GUIDE.md'
+                  Pattern = '(?m)^(\*\*Version:\*\*\s+)([0-9]+\.[0-9]+\.[0-9]+)'
+                  Format  = '**Version:** {0}'
+                  Label   = 'DEMO-GUIDE version'
+              },
+              @{
+                  Path    = 'ROADMAP.md'
+                  Pattern = '(?m)^(## Current Release: v)([0-9]+\.[0-9]+\.[0-9]+)'
+                  Format  = '## Current Release: v{0}'
+                  Label   = 'ROADMAP Current Release header'
               }
           )
 
@@ -162,6 +181,25 @@ jobs:
               Add-Content -Path $changelogPath -Value '' -Encoding utf8
           }
 
+          $psdPath = 'AzVMAvailability/AzVMAvailability.psd1'
+          $psdContent = Get-Content $psdPath -Raw
+          $releaseDesc = if ([string]::IsNullOrWhiteSpace($env:CHANGELOG_SUMMARY)) {
+              "TODO: describe changes for $newVersion before merging."
+          } else {
+              $env:CHANGELOG_SUMMARY
+          }
+          $releaseDescEscaped = $releaseDesc -replace "'", "''"
+          $psdRnPattern = "(?m)^(\s*ReleaseNotes\s*=\s*')((?:''|[^'])*)(')\s*$"
+          $psdRnReplacement = "`${1}v${newVersion}: ${releaseDescEscaped}`${3}"
+          $psdUpdated = [regex]::Replace($psdContent, $psdRnPattern, $psdRnReplacement, 1)
+          if ($psdUpdated -eq $psdContent) { throw "ReleaseNotes pattern did not match in $psdPath" }
+          $psdHadTrailing = $psdContent.EndsWith("`n")
+          Set-Content -Path $psdPath -Value $psdUpdated -NoNewline -Encoding utf8
+          if ($psdHadTrailing -and -not $psdUpdated.EndsWith("`n")) {
+              Add-Content -Path $psdPath -Value '' -Encoding utf8
+          }
+          Write-Host "Updated $psdPath ReleaseNotes -> v${newVersion}: ${releaseDesc}"
+
           "current_version=$currentVersion" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
           "new_version=$newVersion"         | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
           $landmarkJson = $observedLines | ConvertTo-Json -Compress
@@ -198,6 +236,9 @@ jobs:
           Invoke-Git add Get-AzVMAvailability.ps1 `
                   AzVMAvailability/AzVMAvailability.psd1 `
                   AzVMAvailability/Public/Get-AzVMAvailability.ps1 `
+                  README.md `
+                  demo/DEMO-GUIDE.md `
+                  ROADMAP.md `
                   CHANGELOG.md
           Invoke-Git commit -m "chore: bump version $($env:CURRENT_VERSION) -> $($env:NEW_VERSION) ($($env:BUMP_TYPE))"
           Invoke-Git push -u origin $branch
@@ -207,6 +248,7 @@ jobs:
               "| $($l.Label) updated to $($env:NEW_VERSION) | $($l.Path) L$($l.Line) - read by workflow, regex-replaced | [OBSERVED] |"
           }
           $tableRows = @($tableRows) + @("| CHANGELOG stub prepended for $($env:NEW_VERSION) | CHANGELOG.md - release header inserted before prior top release | [OBSERVED] |")
+          $tableRows = @($tableRows) + @("| psd1 ReleaseNotes updated to v$($env:NEW_VERSION) | AzVMAvailability/AzVMAvailability.psd1 - version prefix + changelog_summary | [OBSERVED] |")
 
           $summaryDisplay = if ([string]::IsNullOrWhiteSpace($env:CHANGELOG_SUMMARY)) {
               '_Not provided at dispatch - fill in before requesting review._'
@@ -219,8 +261,11 @@ jobs:
               '',
               "Automated version bump from **$($env:CURRENT_VERSION)** to **$($env:NEW_VERSION)** (``$($env:BUMP_TYPE)``).",
               '',
-              'This PR updates the four authoritative version strings and prepends a CHANGELOG stub.',
+              'This PR updates eight version locations and prepends a CHANGELOG stub.',
               'No module behavior is changed. Generated by `.github/workflows/version-bump.yml`.',
+              '',
+              '> **Note:** `psd1 ReleaseNotes` uses the `changelog_summary` input for the description. Fill it at dispatch or update before merging.',
+              '> **Action required:** Update the `ROADMAP.md` description line (`> **vX.Y.Z:**`) to describe the new release before merging.',
               '',
               "**Changelog summary provided:** $summaryDisplay",
               '',
@@ -267,7 +312,7 @@ jobs:
               '## Quality Checklist',
               '',
               '- [x] **PR markdown renders correctly** - written via `--body-file`',
-              '- [x] **Version strings in sync** - all four authoritative locations updated atomically in one commit',
+              '- [x] **Version strings in sync** - all eight tracked version locations updated atomically in one commit',
               '- [ ] **PSScriptAnalyzer clean** - run locally before merge',
               '- [ ] **Pester tests pass** - run locally before merge',
               '- [ ] **Syntax valid** - `.\tools\Validate-Script.ps1` before merge',

--- a/AzVMAvailability/Public/Get-AzVMAvailability.ps1
+++ b/AzVMAvailability/Public/Get-AzVMAvailability.ps1
@@ -126,7 +126,7 @@ function Get-AzVMAvailability {
     Name:           Get-AzVMAvailability
     Author:         Zachary Luz
     Created:        2026-01-21
-    Version:        2.1.1
+    Version:        2.2.1
     License:        MIT
     Repository:     https://github.com/zacharyluz/Get-AzVMAvailability
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Version bump workflow coverage** — `version-bump.yml` now updates the README badge, demo guide, ROADMAP current-release header, and psd1 `ReleaseNotes` alongside the existing wrapper, manifest, public help, and changelog updates. Current public help and demo-guide version stamps were also realigned to v2.2.1.
 - **Release publish gate** — `release-publish.yml` now logs non-blocking PSScriptAnalyzer diagnostics but filters failures to blocking errors before stopping PSGallery publishing, matching the main lint gate behavior that already reports warnings through SARIF/code scanning.
 - **Manual release publish retry** — `release-publish.yml` can now be run manually for an existing tag, so a release can be published to PSGallery without moving the tag when an older tag contains stale workflow logic. Manual publishes now also validate that the GitHub Release exists before PSGallery publishing and serialize runs per release tag.
 

--- a/demo/DEMO-GUIDE.md
+++ b/demo/DEMO-GUIDE.md
@@ -1,6 +1,6 @@
 # Get-AzVMAvailability — Live Demo Guide
 
-**Version:** 2.1.1 | **Duration:** ~40 minutes + Q&A | **Audience:** Internal Microsoft / External Customers
+**Version:** 2.2.1 | **Duration:** ~40 minutes + Q&A | **Audience:** Internal Microsoft / External Customers
 
 ---
 


### PR DESCRIPTION
## Summary

Supersedes #144 with a clean branch from current `main`.

This keeps the useful version-bump workflow coverage from #144, drops the stale manifest ReleaseNotes edit, and does not reintroduce the temporary `tools/Bump-Version.ps1` script from the old branch history.

## Verification Checklist

- [x] Started from current `origin/main` after #150 and #151 merged.
- [x] Replayed only the useful `version-bump.yml` workflow coverage changes from #144.
- [x] Confirmed `tools/Bump-Version.ps1` is not present in this branch.
- [x] Verified current version landmarks are aligned at `2.2.1` before opening this PR.
- [x] Ran targeted regex validation for all version-bump targets.
- [x] Ran `git diff --check`.
- [x] Parsed `AzVMAvailability/Public/Get-AzVMAvailability.ps1` with the PowerShell parser.
- [ ] GitHub Actions PR checks pass.

### Verified Landmark Table

| Landmark / Claim | Evidence | Tag |
| --- | --- | --- |
| Repo top-level structure includes `.github`, `AzVMAvailability`, `demo`, `docs`, `tests`, `tools`, and root wrapper files. | Ran top-level inventory with `Get-ChildItem -Name` before editing. | [OBSERVED] |
| Entrypoint wrapper is `Get-AzVMAvailability.ps1` and imports/calls the module cmdlet. | Read `Get-AzVMAvailability.ps1`; header describes the thin wrapper behavior and direct module usage. | [OBSERVED] |
| Module loader is `AzVMAvailability/AzVMAvailability.psm1` and dot-sources private/public function files. | Read `AzVMAvailability/AzVMAvailability.psm1`; observed module root, Write-Host override, private directory order, and public dot-sourcing. | [OBSERVED] |
| PR #144 final diff included `.github/workflows/version-bump.yml` and stale `AzVMAvailability/AzVMAvailability.psd1` ReleaseNotes changes. | Ran `gh pr diff 144 --name-only` and read the patch. | [OBSERVED] |
| Replacement branch does not include `tools/Bump-Version.ps1`. | Ran `Test-Path tools\Bump-Version.ps1`; result was `False`. | [OBSERVED] |
| Current version landmarks are aligned at `2.2.1`. | Ran targeted `Select-String` across wrapper, manifest, public function, README, demo guide, and ROADMAP after edits. | [OBSERVED] |
| Version-bump regexes match current branch content. | Ran targeted PowerShell validation for wrapper notes, wrapper `$ScriptVersion`, manifest `ModuleVersion`, public help version, README badge, demo guide version, ROADMAP current-release header, and psd1 `ReleaseNotes`. | [OBSERVED] |

### Behavior Parity

No module behavior changes. Runtime code paths, parameters, JSON contracts, exports, pricing logic, and scanner behavior are unchanged. The only source file change under `AzVMAvailability/Public` updates the help-comment version stamp from `2.1.1` to `2.2.1`.

## Quality Checklist

- [x] Surgical replacement for #144; no stale manifest ReleaseNotes replay.
- [x] No new features, parameters, or behavior paths.
- [x] CHANGELOG updated.
- [x] Whitespace check passed with `git diff --check`.
- [x] PowerShell parse check passed for the touched public function file.
- [x] Targeted workflow regex validation passed.

## Notes

After this replacement PR is open and green, #144 can be closed as superseded.

## Summary by Sourcery

Expand and realign the automated version-bump workflow so it updates all relevant version landmarks and psd1 release notes while syncing existing documentation version stamps to v2.2.1.

Enhancements:
- Extend the version-bump workflow to update README badge, demo guide version, ROADMAP current-release header, and psd1 ReleaseNotes in addition to existing version landmarks.
- Include new verification table entries and PR body guidance to reflect the expanded set of tracked version locations and ReleaseNotes behavior.
- Realign public help metadata and demo guide version stamps to v2.2.1 for consistency with the current release.

CI:
- Refine the version-bump GitHub Actions workflow to track and commit updates to eight coordinated version locations and psd1 ReleaseNotes in a single atomic bump.

Documentation:
- Document the expanded version-bump workflow behavior in the CHANGELOG under the unreleased fixes.