### PR TITLE
chore: bump version 2.2.2 → 2.3.0 (minor)

### DIFF
--- a/AzVMAvailability/AzVMAvailability.psd1
+++ b/AzVMAvailability/AzVMAvailability.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule        = 'AzVMAvailability.psm1'
-    ModuleVersion     = '2.2.2'
+    ModuleVersion     = '2.3.0'
     GUID              = '7f42e8d6-e85d-4e31-a541-d9af648a5269'
     Author            = 'Zachary Luz'
     CompanyName       = 'Community'
@@ -23,7 +23,7 @@
             Tags         = @('Azure', 'VM', 'SKU', 'Capacity', 'Availability', 'Quota', 'Pricing')
             LicenseUri   = 'https://github.com/zacharyluz/Get-AzVMAvailability/blob/main/LICENSE'
             ProjectUri   = 'https://github.com/zacharyluz/Get-AzVMAvailability'
-            ReleaseNotes = 'v2.2.2: PSGallery package parity — release publishing now stages the runtime UpgradePath data, README, LICENSE, CHANGELOG, examples, and curated docs into the module package before publishing, so PSGallery installs ship the same assets as repo-based usage. A package-layout Pester test guards those assets. Also: version-bump workflow now updates all eight version stamps; release-publish gate logs non-blocking PSScriptAnalyzer diagnostics but only blocks on errors; release-publish.yml supports manual workflow_dispatch retry against an existing tag. See CHANGELOG.md.'
+            ReleaseNotes = 'v2.3.0: TODO: describe changes for 2.3.0 before merging.'
         }
     }
 }

--- a/AzVMAvailability/Public/Get-AzVMAvailability.ps1
+++ b/AzVMAvailability/Public/Get-AzVMAvailability.ps1
@@ -131,7 +131,7 @@ function Get-AzVMAvailability {
     Name:           Get-AzVMAvailability
     Author:         Zachary Luz
     Created:        2026-01-21
-    Version:        2.2.2
+    Version:        2.3.0
     License:        MIT
     Repository:     https://github.com/zacharyluz/Get-AzVMAvailability
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.0] - 2026-05-21
+
+### Changed
+- _TODO: describe the change before merging._
+
 ## [Unreleased]
 
 ### Added

--- a/Get-AzVMAvailability.ps1
+++ b/Get-AzVMAvailability.ps1
@@ -16,7 +16,7 @@
     Name:           Get-AzVMAvailability
     Author:         Zachary Luz
     Created:        2026-01-21
-    Version:        2.2.2
+    Version:        2.3.0
     License:        MIT
     Repository:     https://github.com/zacharyluz/Get-AzVMAvailability
 
@@ -188,7 +188,7 @@ param(
 )
 
 # Version for Validate-Script.ps1 parity check (must match .psd1 ModuleVersion)
-$ScriptVersion = "2.2.2"
+$ScriptVersion = "2.3.0"
 Write-Verbose "Get-AzVMAvailability wrapper v$ScriptVersion"
 
 # Import the AzVMAvailability module from the same directory as this script

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A PowerShell tool for checking Azure VM SKU availability across regions - find w
 ![PowerShell](https://img.shields.io/badge/PowerShell-7.0%2B-blue)
 ![Azure](https://img.shields.io/badge/Azure-Az%20Modules-0078D4)
 ![License](https://img.shields.io/badge/License-MIT-green)
-![Version](https://img.shields.io/badge/Version-2.2.2-brightgreen)
+![Version](https://img.shields.io/badge/Version-2.3.0-brightgreen)
 
 ## Overview
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-## Current Release: v2.2.2
+## Current Release: v2.3.0
 
 > **v2.2.2:** PSGallery package parity with the GitHub repo — release publishing now stages the runtime `UpgradePath` data, README, LICENSE, CHANGELOG, examples, and curated docs into the module package before publishing, with a Pester package-layout guard. `version-bump.yml` now also updates the README badge, demo guide, ROADMAP current-release header, and psd1 `ReleaseNotes`. `release-publish.yml` runs PSScriptAnalyzer with `-Severity Error` (only Error-severity findings block; uses shared `PSScriptAnalyzerSettings.psd1`) before publishing, supports manual retry against an existing tag, and serializes runs per release. See [CHANGELOG.md](CHANGELOG.md) for details.
 >

--- a/demo/DEMO-GUIDE.md
+++ b/demo/DEMO-GUIDE.md
@@ -1,6 +1,6 @@
 # Get-AzVMAvailability — Live Demo Guide
 
-**Version:** 2.2.2 | **Duration:** ~40 minutes + Q&A | **Audience:** Internal Microsoft / External Customers
+**Version:** 2.3.0 | **Duration:** ~40 minutes + Q&A | **Audience:** Internal Microsoft / External Customers
 
 ---
 


### PR DESCRIPTION
Version bump from the automated workflow. Updates psd1, wrapper, public function, README badge, demo guide, ROADMAP header, and CHANGELOG stub.

## Summary by Sourcery

Bump the AzVMAvailability module version from 2.2.2 to 2.3.0 across code, metadata, and docs in preparation for the 2.3.0 release.

Documentation:
- Update README badge, ROADMAP current release header, and demo guide to reference version 2.3.0.

Chores:
- Increment module manifest, wrapper script, and public function version stamps to 2.3.0 and add a stub 2.3.0 section to the changelog and release notes.