### PR TITLE
ci: require changelog_summary + block TODO stubs from merging

### DIFF
--- a/.github/workflows/release-metadata-guard.yml
+++ b/.github/workflows/release-metadata-guard.yml
@@ -84,6 +84,13 @@ jobs:
               throw "ScriptVersion changed ($baseVersion -> $headVersion) but CHANGELOG.md is missing heading: ## [$headVersion]"
             }
             Write-Host "CHANGELOG heading ## [$headVersion] found."
+
+            # Block merge if CHANGELOG entry still has a TODO stub
+            $versionSection = [regex]::Match($changelog, "(?s)## \[$([regex]::Escape($headVersion))\][^\n]*\n(.*?)(?=\n## \[|\z)")
+            if ($versionSection.Success -and $versionSection.Groups[1].Value -match '_TODO:') {
+              throw "CHANGELOG ## [$headVersion] still contains a _TODO: stub. Fill in the release notes before merging."
+            }
+            Write-Host "CHANGELOG ## [$headVersion] has no TODO stubs."
           } else {
             Write-Host "ScriptVersion unchanged ($headVersion). Verifying [Unreleased] section has content..."
             # Capture content between ## [Unreleased] heading and the next ## [ heading

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -20,10 +20,9 @@ on:
           - minor
           - major
       changelog_summary:
-        description: "One-line summary for CHANGELOG stub (leave blank to fill in PR)"
-        required: false
+        description: "One-line summary for CHANGELOG and psd1 ReleaseNotes (REQUIRED)"
+        required: true
         type: string
-        default: ""
       draft_pr:
         description: "Open PR as draft"
         required: false
@@ -154,11 +153,10 @@ jobs:
           $changelog = Get-Content $changelogPath -Raw
           $date = (Get-Date -Format 'yyyy-MM-dd')
           $summary = $env:CHANGELOG_SUMMARY
-          $summaryLine = if ([string]::IsNullOrWhiteSpace($summary)) {
-              '- _TODO: describe the change before merging._'
-          } else {
-              "- $summary"
+          if ([string]::IsNullOrWhiteSpace($summary)) {
+              throw 'changelog_summary is required. Provide a one-line description of the release.'
           }
+          $summaryLine = "- $summary"
           $stubLines = @(
               "## [$newVersion] - $date",
               '',
@@ -183,11 +181,7 @@ jobs:
 
           $psdPath = 'AzVMAvailability/AzVMAvailability.psd1'
           $psdContent = Get-Content $psdPath -Raw
-          $releaseDesc = if ([string]::IsNullOrWhiteSpace($env:CHANGELOG_SUMMARY)) {
-              "TODO: describe changes for $newVersion before merging."
-          } else {
-              $env:CHANGELOG_SUMMARY
-          }
+          $releaseDesc = $env:CHANGELOG_SUMMARY
           $releaseDescEscaped = $releaseDesc -replace "'", "''"
           $psdRnPattern = "(?m)^(\s*ReleaseNotes\s*=\s*')((?:''|[^'])*)(')\s*$"
           $psdRnReplacement = "`${1}v${newVersion}: ${releaseDescEscaped}`${3}"
@@ -311,11 +305,7 @@ jobs:
           $tableRows = @($tableRows) + @("| CHANGELOG stub prepended for $($env:NEW_VERSION) | CHANGELOG.md - release header inserted before prior top release | [OBSERVED] |")
           $tableRows = @($tableRows) + @("| psd1 ReleaseNotes updated to v$($env:NEW_VERSION) | AzVMAvailability/AzVMAvailability.psd1 - version prefix + changelog_summary | [OBSERVED] |")
 
-          $summaryDisplay = if ([string]::IsNullOrWhiteSpace($env:CHANGELOG_SUMMARY)) {
-              '_Not provided at dispatch - fill in before requesting review._'
-          } else {
-              $env:CHANGELOG_SUMMARY
-          }
+          $summaryDisplay = $env:CHANGELOG_SUMMARY
 
           $bodyLines = @(
               '## Description',


### PR DESCRIPTION
Two guardrails to prevent the v2.3.0 -> v2.3.1 metadata-only patch bump pattern:

1. **changelog_summary is now required** in version-bump workflow dispatch — no more blank summaries producing TODO stubs
2. **Release Metadata Guard blocks merge** if the CHANGELOG entry for the bumped version still contains a _TODO: stub

These make it structurally impossible to release with incomplete docs.

## Summary by Sourcery

Enforce non-empty changelog summaries in the version-bump workflow and prevent merging releases whose CHANGELOG entries still contain TODO stubs.

CI:
- Require a non-empty changelog_summary input in the version-bump workflow and propagate it directly into CHANGELOG and psd1 ReleaseNotes instead of generating TODO placeholders.
- Extend the release-metadata-guard workflow to fail when the CHANGELOG section for the bumped version still contains a TODO stub, blocking merges with incomplete release notes.