### PR TITLE
ci: add review threads gate — block merge on unresolved PR comments

### DIFF
--- a/.github/workflows/review-threads-gate.yml
+++ b/.github/workflows/review-threads-gate.yml
@@ -1,0 +1,84 @@
+name: "Review Threads Gate"
+
+# Blocks merge if any PR review threads are unresolved.
+# Contributors must either fix Copilot/reviewer findings or reply with
+# a rationale and resolve the thread themselves.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  pull_request_review:
+    types: [submitted]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  check-threads:
+    name: All review threads resolved
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for unresolved review threads
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const prNumber = context.payload.pull_request?.number
+              ?? context.payload.review?.pull_request?.number
+              ?? context.payload.comment?.pull_request_url?.split('/').pop();
+
+            if (!prNumber) {
+              core.setFailed('Could not determine PR number from event payload.');
+              return;
+            }
+
+            // GraphQL query to get all review threads and their resolved status
+            const query = `query($owner: String!, $repo: String!, $pr: Int!) {
+              repository(owner: $owner, name: $repo) {
+                pullRequest(number: $pr) {
+                  reviewThreads(first: 100) {
+                    nodes {
+                      isResolved
+                      isOutdated
+                      comments(first: 1) {
+                        nodes {
+                          author { login }
+                          body
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }`;
+
+            const result = await github.graphql(query, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pr: Number(prNumber)
+            });
+
+            const threads = result.repository.pullRequest.reviewThreads.nodes;
+            const unresolved = threads.filter(t => !t.isResolved && !t.isOutdated);
+
+            if (unresolved.length === 0) {
+              core.info(`✅ All ${threads.length} review threads are resolved or outdated.`);
+              return;
+            }
+
+            // Build a summary of unresolved threads
+            const summary = unresolved.map((t, i) => {
+              const comment = t.comments.nodes[0];
+              const author = comment?.author?.login ?? 'unknown';
+              const preview = (comment?.body ?? '').substring(0, 120).replace(/\n/g, ' ');
+              return `  ${i + 1}. @${author}: ${preview}${comment?.body?.length > 120 ? '...' : ''}`;
+            }).join('\n');
+
+            core.setFailed(
+              `❌ ${unresolved.length} unresolved review thread(s) found.\n\n` +
+              `All review comments must be resolved before merging.\n` +
+              `For each comment: fix the issue, OR reply with your rationale and resolve the thread.\n\n` +
+              `Unresolved threads:\n${summary}`
+            );

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,18 @@ Thank you for your interest in contributing! This document provides guidelines f
 5. Commit with clear messages (git commit -m Add amazing feature)
 6. Push to your branch (git push origin feature/amazing-feature)
 7. Open a Pull Request
+8. **Resolve all review comments** (see Review Comment Policy below)
+
+### Review Comment Policy (Required)
+
+GitHub Copilot and other reviewers will leave comments on your PR automatically. **All review threads must be resolved before the PR can be merged.** A CI check enforces this — PRs with unresolved threads cannot pass the gate.
+
+For each review comment, you must do one of:
+
+1. **Agree** — fix the issue in a follow-up commit and resolve the thread.
+2. **Disagree** — reply with a specific rationale explaining why the suggestion doesn't apply, then resolve the thread yourself.
+
+Simply ignoring review comments is not acceptable. The maintainer will not merge PRs with open threads.
 
 ### PR Description Formatting (Required)
 


### PR DESCRIPTION
Adds a CI check that queries all review threads via GraphQL and fails if any are unresolved. Contributors must either fix the finding or reply with a rationale and resolve the thread. CONTRIBUTING.md updated with the policy.

## Summary by Sourcery

Enforce that pull requests cannot be merged while any active review threads remain unresolved by adding a new CI gate and documenting the required review comment resolution workflow.

Build:
- Add a GitHub Actions workflow that queries PR review threads via GraphQL and fails the check when unresolved, non-outdated threads are present.

Documentation:
- Document a mandatory review comment policy in CONTRIBUTING, requiring contributors to resolve or explicitly address all review threads before merge.