### PR TITLE
fix: clarify restriction status semantics across all user-facing text

### DIFF
--- a/.github/skills/azure-vm-availability/SKILL.md
+++ b/.github/skills/azure-vm-availability/SKILL.md
@@ -1,27 +1,31 @@
 ---
 name: azure-vm-availability
-description: "Scan Azure regions for real-time VM SKU availability, capacity status, quota, pricing, and image compatibility using Get-AzVMAvailability. USE FOR: where can I deploy VMs, check VM capacity, GPU availability, find available regions, VM SKU restricted, capacity constrained, find alternative SKU, recommend replacement VM, compare regions for VMs, DR region planning, check zone availability, is this SKU available, scan regions. DO NOT USE FOR: general VM size recommendations without Azure login (use azure-compute), quota management via CLI (use azure-quotas), deploying VMs (use azure-prepare)."
+description: "Scan Azure regions for VM SKU restriction status, quota headroom, pricing, placement signals, and image compatibility using Get-AzVMAvailability. Reports deployment readiness signals, not live capacity guarantees. USE FOR: where can I deploy VMs, check VM SKU restrictions, GPU availability, find available regions, VM SKU restricted, capacity constrained, find alternative SKU, recommend replacement VM, compare regions for VMs, DR region planning, check zone availability, is this SKU available, scan regions. DO NOT USE FOR: general VM size recommendations without Azure login (use azure-compute), quota management via CLI (use azure-quotas), deploying VMs (use azure-prepare)."
 license: MIT
 metadata:
   author: Zachary Luz
   version: "1.1.0"  # Skill version (independent of script version 1.11.0)
 ---
 
-# Azure VM Availability — Live Capacity Scanner
+# Azure VM Availability - SKU Restriction and Quota Scanner
 
 > **AUTHORITATIVE GUIDANCE** — This skill teaches you when and how to invoke
-> the `Get-AzVMAvailability.ps1` script via terminal for real-time Azure VM
-> capacity scanning. The script is the execution engine; this skill is the
+> the `Get-AzVMAvailability.ps1` script via terminal for Azure VM SKU
+> restriction, quota, pricing, and placement-signal scanning. The script is the
 > routing layer.
+
+> **Interpretation rule:** Status values come from ARM `Microsoft.Compute/skus`
+> restriction metadata. `OK` means no ARM SKU restriction was returned for the
+> scanned scope; it is not a live physical capacity guarantee.
 
 ## When to Use This Skill
 
 Invoke this skill when the user wants to:
-- Check **real-time** VM SKU availability across Azure regions
-- Find which regions have capacity for a specific VM family or SKU
+- Check VM SKU availability metadata across Azure regions
+- Find which regions return no ARM SKU restrictions for a specific VM family or SKU
 - Discover GPU/HPC SKU availability (NC, ND, NV series are often constrained)
-- Find **alternative SKUs** when a target VM is capacity-constrained or restricted
-- Plan **disaster recovery** by comparing capacity across region pairs
+- Find **alternative SKUs** when a target VM is constrained or restricted
+- Plan **disaster recovery** by comparing SKU restriction status across region pairs
 - Verify **image compatibility** (Gen1/Gen2, x64/ARM64) before deployment
 - See **pricing** alongside availability (retail or negotiated EA/MCA/CSP)
 - Export availability data to CSV/XLSX for reporting
@@ -95,7 +99,7 @@ User request
     ├─ "Where can I deploy Standard_D4s_v5?"
     │   └─ THIS SKILL → Scan mode
     │
-    ├─ "Is GPU capacity available in eastus?"
+    ├─ "Is this GPU SKU unrestricted in eastus?"
     │   └─ THIS SKILL → Scan mode with FamilyFilter
     │
     ├─ "E64pds_v6 is constrained, what else can I use?"
@@ -115,9 +119,9 @@ User request
 
 ## Core Workflows
 
-### Workflow 1: Region Capacity Scan
+### Workflow 1: Region Restriction Scan
 
-**Scenario:** Check which regions have capacity for specific VM SKUs or families.
+**Scenario:** Check which regions return no ARM SKU restrictions for specific VM SKUs or families.
 
 ```powershell
 # Basic scan — specific SKU across regions
@@ -196,7 +200,7 @@ User request
 
 ### Workflow 7: Fleet Readiness (BOM Validation)
 
-**Scenario:** Validate that an entire VM fleet (bill of materials) can be deployed — checks capacity and quota for every SKU in the BOM simultaneously.
+**Scenario:** Validate an entire VM fleet (bill of materials) against ARM SKU restriction status and quota for every SKU in the BOM simultaneously.
 
 ```powershell
 # Step 1: Generate template files (no Azure login needed)
@@ -240,7 +244,7 @@ Standard_D16ls_v6,1
 
 **Column name flexibility:** The parser accepts `SKU`, `Name`, or `VmSize` for the SKU column, and `Qty`, `Quantity`, or `Count` for the quantity column. Duplicate SKU rows are summed automatically.
 
-**Output:** Color-coded per-SKU capacity table + per-family quota pass/fail (Used/Available/Limit) + overall PASS/FAIL verdict.
+**Output:** Color-coded per-SKU restriction-status table + per-family quota pass/fail (Used/Available/Limit) + overall PASS/FAIL verdict.
 
 **When to route here vs Recommend mode:**
 - User has a specific BOM (list of SKUs + quantities) → **Fleet mode**
@@ -390,15 +394,17 @@ Max 5 regions per scan for performance.
 
 ---
 
-## Capacity Status Meanings
+## SKU Restriction Status Meanings
+
+`capacity` remains in JSON and table fields for schema compatibility. Interpret it as ARM SKU restriction status, not live allocation capacity.
 
 | Status | Meaning | Action |
 |--------|---------|--------|
-| OK | Ready to deploy, no restrictions | Proceed |
-| LIMITED | Subscription can't use this SKU | Request access via support ticket |
-| CAPACITY-CONSTRAINED | Azure low on hardware | Try different zone or wait |
-| PARTIAL | Some zones work, others blocked | No zone redundancy available |
-| RESTRICTED | Cannot deploy | Pick different region or SKU |
+| OK | No ARM SKU restriction returned | Validate quota, placement, and deployment dependencies |
+| LIMITED | Subscription/SKU access restriction | Request access or quota review if needed |
+| CAPACITY-CONSTRAINED | Some zones returned ARM restriction records | Try another zone and verify placement/deployment |
+| PARTIAL | Mixed zone restriction state | Treat zone redundancy as limited |
+| RESTRICTED | Blocking ARM restriction returned | Pick different region or SKU |
 
 ---
 
@@ -406,9 +412,9 @@ Max 5 regions per scan for performance.
 
 When presenting results to the user:
 
-1. **Scan mode**: Summarize which families/SKUs are available (OK) vs constrained, highlight best regions
+1. **Scan mode**: Summarize which families/SKUs returned no ARM restrictions (OK) vs constrained, highlight best regions
 2. **Recommend mode**: Present the top alternatives ranked by similarity score, note any fleet warnings (mixed CPU vendors, mixed disk types)
-3. **Always mention**: quota availability, zone coverage, and pricing if shown
+3. **Always mention**: quota availability, zone coverage, pricing if shown, and that OK is not a live capacity guarantee
 4. **If no OK results**: Suggest expanding regions, lowering MinScore, or trying different families
 
 ---

--- a/AzVMAvailability/Private/Format/Write-RecommendOutputContract.ps1
+++ b/AzVMAvailability/Private/Format/Write-RecommendOutputContract.ps1
@@ -16,7 +16,9 @@ function Write-RecommendOutputContract {
 
     Write-Host "`n" -NoNewline
     Write-Host ("=" * $OutputWidth) -ForegroundColor Gray
-    Write-Host "CAPACITY RECOMMENDER" -ForegroundColor Green
+    Write-Host "SKU RECOMMENDER" -ForegroundColor Green
+    Write-Host "The Capacity column shows ARM SKU restriction status, not live allocatable capacity." -ForegroundColor DarkYellow
+    Write-Host "OK = no restriction returned. Deployment can still fail due to quota, placement, or policy." -ForegroundColor DarkYellow
     Write-Host ("=" * $OutputWidth) -ForegroundColor Gray
     Write-Host ""
 
@@ -60,7 +62,7 @@ function Write-RecommendOutputContract {
     $unavailableRegions = @($targetAvailability | Where-Object { $_.Status -ne 'OK' })
     if ($availableRegions.Count -gt 0) {
         $availableRegionNames = @($availableRegions | ForEach-Object { $_.Region })
-        Write-Host "  $($Icons.Check) Available in: $($availableRegionNames -join ', ')" -ForegroundColor Green
+        Write-Host "  $($Icons.Check) Unrestricted in: $($availableRegionNames -join ', ')" -ForegroundColor Green
     }
     foreach ($ur in $unavailableRegions) {
         Write-Host "  $($Icons.Error) $($ur.Region): $($ur.Status)" -ForegroundColor Red
@@ -154,7 +156,7 @@ function Write-RecommendOutputContract {
 
         if ($smallerOK.Count -gt 0) {
             Write-Host ""
-            Write-Host "  $($Icons.Warning) CONSIDER SMALLER (better availability, if your workload supports it):" -ForegroundColor Yellow
+            Write-Host "  $($Icons.Warning) CONSIDER SMALLER (fewer restrictions, if your workload supports it):" -ForegroundColor Yellow
             foreach ($s in $smallerOK) {
                 Write-Host "    $($s.sku) ($($s.vCPU) vCPU / $($s.memGiB) GiB) — $($s.capacity) in $($s.region)" -ForegroundColor DarkYellow
             }
@@ -163,11 +165,12 @@ function Write-RecommendOutputContract {
 
     Write-Host ''
     Write-Host 'STATUS KEY:' -ForegroundColor DarkGray
-    Write-Host '  OK                    = Ready to deploy. No restrictions.' -ForegroundColor Green
-    Write-Host '  CAPACITY-CONSTRAINED  = Azure is low on hardware. Try a different zone or wait.' -ForegroundColor Yellow
-    Write-Host "  LIMITED               = Your subscription can't use this. Request access via support ticket." -ForegroundColor Yellow
-    Write-Host '  PARTIAL               = Some zones work, others are blocked. No zone redundancy.' -ForegroundColor Yellow
-    Write-Host '  BLOCKED               = Cannot deploy. Pick a different region or SKU.' -ForegroundColor Red
+    Write-Host '  OK                    = No ARM restriction returned. Not a capacity guarantee.' -ForegroundColor Green
+    Write-Host '  CAPACITY-CONSTRAINED  = Some zones have ARM restrictions; others are clear. Verify before deploying.' -ForegroundColor Yellow
+    Write-Host '  LIMITED               = Subscription/SKU access restriction; request access if needed.' -ForegroundColor Yellow
+    Write-Host '  PARTIAL               = Mixed zone restriction state; zone redundancy may be limited.' -ForegroundColor Yellow
+    Write-Host '  BLOCKED               = Blocking ARM restriction returned; pick another region or SKU.' -ForegroundColor Red
+    Write-Host '  NOTE                  = These reflect ARM restriction metadata, not live physical capacity.' -ForegroundColor DarkYellow
     Write-Host ''
     Write-Host 'DISK CODES:' -ForegroundColor DarkGray
     Write-Host '  NV+T = NVMe + local temp disk   NVMe = NVMe only (no temp disk)' -ForegroundColor DarkGray

--- a/AzVMAvailability/Private/Inventory/Write-InventoryReadinessSummary.ps1
+++ b/AzVMAvailability/Private/Inventory/Write-InventoryReadinessSummary.ps1
@@ -22,6 +22,8 @@ function Write-InventoryReadinessSummary {
     Write-Host "INVENTORY READINESS SUMMARY" -ForegroundColor Cyan
     Write-Host ("=" * 100) -ForegroundColor Gray
     Write-Host "Inventory: $($Inventory.Count) SKUs | $totalVMs VMs | $totalvCPU vCPUs total" -ForegroundColor White
+    Write-Host "The Capacity column shows ARM SKU restriction status, not live allocatable capacity." -ForegroundColor DarkYellow
+    Write-Host "OK = no restriction returned. Deployment can still fail due to quota, placement, or policy." -ForegroundColor DarkYellow
     Write-Host ""
 
     # Per-SKU table
@@ -64,11 +66,11 @@ function Write-InventoryReadinessSummary {
     Write-Host ""
     if ($allPass) {
         Write-Host "INVENTORY READINESS: PASS" -ForegroundColor Green -BackgroundColor Black
-        Write-Host "All SKUs have capacity and quota covers the inventory demand." -ForegroundColor Green
+        Write-Host "All SKUs returned no blocking ARM SKU restrictions and quota covers the inventory demand." -ForegroundColor Green
     }
     else {
         Write-Host "INVENTORY READINESS: FAIL" -ForegroundColor Red -BackgroundColor Black
-        Write-Host "One or more SKUs have capacity issues or insufficient quota." -ForegroundColor Red
+        Write-Host "One or more SKUs returned blocking ARM SKU restrictions or insufficient quota." -ForegroundColor Red
         Write-Host "Request quota increase: https://aka.ms/ProdportalCRP/?#create/Microsoft.Support/Parameters/" -ForegroundColor Yellow
     }
 

--- a/AzVMAvailability/Public/Get-AzVMAvailability.ps1
+++ b/AzVMAvailability/Public/Get-AzVMAvailability.ps1
@@ -4,12 +4,12 @@ function Get-AzVMAvailability {
     Get-AzVMAvailability - SKU availability, ARM restriction, quota, and pricing scanner.
 
 .DESCRIPTION
-    Scans Azure regions for VM SKU availability, ARM SKU restriction status, and quota to help plan deployments.
+    Scans Azure regions for VM SKU restriction status, quota headroom, and deployment readiness signals.
     ARM SKU restriction status is not a live physical capacity guarantee. OK means the Microsoft.Compute/skus API did
     not return a blocking restriction record for that SKU/region/zone; allocation can still fail because of quota,
     placement, transient platform capacity, policy, or deployment-time constraints.
     Provides a comprehensive view of:
-    - All VM SKU families available in each region
+    - All VM SKU families in each region
     - ARM SKU restriction status (OK, LIMITED, CAPACITY-CONSTRAINED, RESTRICTED)
     - Subscription-level restrictions
     - Available vCPU quota per family
@@ -111,11 +111,11 @@ function Get-AzVMAvailability {
 
 .PARAMETER MinvCPU
     Minimum vCPU count for recommended alternatives. SKUs below this are excluded.
-    If smaller SKUs have better availability, a suggestion note is shown.
+    If smaller SKUs have fewer restrictions, a suggestion note is shown.
 
 .PARAMETER MinMemoryGB
     Minimum memory in GB for recommended alternatives. SKUs below this are excluded.
-    If smaller SKUs have better availability, a suggestion note is shown.
+    If smaller SKUs have fewer restrictions, a suggestion note is shown.
 
 .PARAMETER JsonOutput
     Emit structured JSON instead of console tables. Designed for the AzVMAvailability-Agent

--- a/AzVMAvailability/Public/Get-AzVMAvailability.ps1
+++ b/AzVMAvailability/Public/Get-AzVMAvailability.ps1
@@ -4971,9 +4971,9 @@ if ($ExportPath) {
                 [PSCustomObject]@{ Category = "STATUS FORMAT"; Item = "STATUS (X/Y)"; Description = "X = SKUs with no returned ARM restriction, Y = total SKUs in family for that region" }
                 [PSCustomObject]@{ Category = "STATUS FORMAT"; Item = "Example: OK (5/8)"; Description = "5 out of 8 SKUs returned no ARM restriction with OK status" }
                 [PSCustomObject]@{ Category = ""; Item = ""; Description = "" }
-                [PSCustomObject]@{ Category = "SKU RESTRICTION STATUS"; Item = "OK"; Description = "No ARM SKU restriction returned for the scanned scope. Not a live capacity guarantee." }
+                [PSCustomObject]@{ Category = "SKU RESTRICTION STATUS"; Item = "OK"; Description = "No ARM restriction returned. Not a live capacity or allocation guarantee." }
                 [PSCustomObject]@{ Category = "SKU RESTRICTION STATUS"; Item = "LIMITED"; Description = "Subscription/SKU access restriction; request access if needed." }
-                [PSCustomObject]@{ Category = "SKU RESTRICTION STATUS"; Item = "CAPACITY-CONSTRAINED"; Description = "Some zones returned ARM restriction records; verify placement/deployment." }
+                [PSCustomObject]@{ Category = "SKU RESTRICTION STATUS"; Item = "CAPACITY-CONSTRAINED"; Description = "Some zones have ARM restrictions; others are clear. Verify placement before deploying." }
                 [PSCustomObject]@{ Category = "SKU RESTRICTION STATUS"; Item = "PARTIAL"; Description = "Mixed zone restriction state; zone redundancy may be limited." }
                 [PSCustomObject]@{ Category = "SKU RESTRICTION STATUS"; Item = "RESTRICTED"; Description = "Blocking ARM restriction returned; pick another region or SKU." }
                 [PSCustomObject]@{ Category = "SKU RESTRICTION STATUS"; Item = "N/A"; Description = "SKU family not returned in this region." }
@@ -4989,11 +4989,11 @@ if ($ExportPath) {
                 [PSCustomObject]@{ Category = "DETAILS COLUMNS"; Item = "vCPU"; Description = "Number of virtual CPUs" }
                 [PSCustomObject]@{ Category = "DETAILS COLUMNS"; Item = "MemGiB"; Description = "Memory in GiB" }
                 [PSCustomObject]@{ Category = "DETAILS COLUMNS"; Item = "Zones"; Description = "Availability zones where SKU is available" }
-                [PSCustomObject]@{ Category = "DETAILS COLUMNS"; Item = "Capacity"; Description = "Legacy field name containing ARM SKU restriction status" }
+                [PSCustomObject]@{ Category = "DETAILS COLUMNS"; Item = "Capacity"; Description = "ARM SKU restriction status (will be renamed to RestrictionStatus in a future release)" }
                 [PSCustomObject]@{ Category = "DETAILS COLUMNS"; Item = "Restrictions"; Description = "ARM SKU restriction reason codes and messages" }
                 [PSCustomObject]@{ Category = "DETAILS COLUMNS"; Item = "QuotaAvail"; Description = "Available vCPU quota for this family (Limit - Current Usage)" }
                 [PSCustomObject]@{ Category = ""; Item = ""; Description = "" }
-                [PSCustomObject]@{ Category = "COLOR CODING"; Item = "Green"; Description = "No ARM SKU restriction returned; still validate quota and placement." }
+                [PSCustomObject]@{ Category = "COLOR CODING"; Item = "Green"; Description = "No ARM restriction returned; still validate quota, placement, and policy." }
                 [PSCustomObject]@{ Category = "COLOR CODING"; Item = "Yellow/Orange"; Description = "ARM restriction signal present; review status and zones." }
                 [PSCustomObject]@{ Category = "COLOR CODING"; Item = "Red"; Description = "Blocking ARM restriction returned; pick another region or SKU." }
                 [PSCustomObject]@{ Category = "COLOR CODING"; Item = "Gray"; Description = "Not returned in this region." }

--- a/AzVMAvailability/Public/Get-AzVMAvailability.ps1
+++ b/AzVMAvailability/Public/Get-AzVMAvailability.ps1
@@ -1,13 +1,16 @@
 function Get-AzVMAvailability {
 <#
 .SYNOPSIS
-    Get-AzVMAvailability - Comprehensive SKU availability and capacity scanner.
+    Get-AzVMAvailability - SKU availability, ARM restriction, quota, and pricing scanner.
 
 .DESCRIPTION
-    Scans Azure regions for VM SKU availability and capacity status to help plan deployments.
+    Scans Azure regions for VM SKU availability, ARM SKU restriction status, and quota to help plan deployments.
+    ARM SKU restriction status is not a live physical capacity guarantee. OK means the Microsoft.Compute/skus API did
+    not return a blocking restriction record for that SKU/region/zone; allocation can still fail because of quota,
+    placement, transient platform capacity, policy, or deployment-time constraints.
     Provides a comprehensive view of:
     - All VM SKU families available in each region
-    - Capacity status (OK, LIMITED, CAPACITY-CONSTRAINED, RESTRICTED)
+    - ARM SKU restriction status (OK, LIMITED, CAPACITY-CONSTRAINED, RESTRICTED)
     - Subscription-level restrictions
     - Available vCPU quota per family
     - Zone availability information
@@ -16,7 +19,7 @@ function Get-AzVMAvailability {
     Key features:
     - Parallel region scanning for speed (~5 seconds for 3 regions)
     - Scans ALL VM families automatically
-    - Color-coded capacity reporting
+    - Color-coded ARM restriction reporting
     - Interactive drill-down by family/SKU
     - CSV/XLSX export with detailed breakdowns
     - Auto-detects Unicode support for icons
@@ -1647,6 +1650,9 @@ Write-Host "`n" -NoNewline
 Write-Host ("=" * $script:OutputWidth) -ForegroundColor Gray
 Write-Host "GET-AZVMAVAILABILITY v$ScriptVersion" -ForegroundColor Green
 Write-Host "Personal project — not an official Microsoft product. Provided AS IS." -ForegroundColor DarkGray
+Write-Host "Restriction status: labels come from ARM Microsoft.Compute/skus restriction metadata." -ForegroundColor DarkYellow
+Write-Host "OK = no blocking restriction returned. This is NOT a live capacity or allocation guarantee." -ForegroundColor DarkYellow
+Write-Host "Deployment can still fail due to quota, placement, policy, or transient platform conditions." -ForegroundColor DarkYellow
 Write-Host ("=" * $script:OutputWidth) -ForegroundColor Gray
 Write-Host "Subscriptions: $($TargetSubIds.Count) | Regions: $($Regions -join ', ')" -ForegroundColor Cyan
 if ($SkuFilter -and $SkuFilter.Count -gt 0) {
@@ -2004,7 +2010,6 @@ try {
                     $authPattern = $using:authErrorPattern
                     $skipQuota = $using:NoQuota.IsPresent
                     $counter = $using:scanCounter
-                    $total = $using:totalItems
 
                     # Inline retry — parallel runspaces cannot see script-scope functions
                     $retryCall = {
@@ -2516,7 +2521,7 @@ if (($LifecycleRecommendations -or $LifecycleScan) -and $lifecycleEntries.Count 
                 }
             }
 
-            # Detect lifecycle risk: old generation, capacity issues, no alternatives
+            # Detect lifecycle risk: old generation, SKU restriction signals, no alternatives
             $generation = if ($target.Name -match '_v(\d+)$') { [int]$Matches[1] } else { 1 }
             $targetAvail = $recOutput.targetAvailability
 
@@ -2554,7 +2559,6 @@ if (($LifecycleRecommendations -or $LifecycleScan) -and $lifecycleEntries.Count 
                     $aggLimit = 0; $aggCurrent = 0
                     foreach ($pair in $perSubMap.GetEnumerator()) {
                         $pSubId = [string]$pair.Key
-                        $pQty = [int]$pair.Value
                         $quotaTotalDeployingSubs++
                         $subQuotaLookup = $lcPerSubQuota["$pSubId|$deployedRegion"]
                         if (-not $subQuotaLookup) { continue }
@@ -2696,7 +2700,7 @@ if (($LifecycleRecommendations -or $LifecycleScan) -and $lifecycleEntries.Count 
                 if ($riskLevel -ne 'High') { $riskLevel = 'High' }
             }
 
-            if ($hasCapacityIssues) { $riskReasons.Add("Capacity$(if ($deployedRegion) { " ($deployedRegion)" } else { '' })"); $riskLevel = 'High' }
+            if ($hasCapacityIssues) { $riskReasons.Add("SKU restriction$(if ($deployedRegion) { " ($deployedRegion)" } else { '' })"); $riskLevel = 'High' }
             if ($quotaInsufficient) {
                 $qReason = if ($quotaTotalDeployingSubs -gt 0) {
                     "Quota: family over limit in $quotaDeficitSubs of $quotaTotalDeployingSubs deploying sub(s)"
@@ -3610,12 +3614,12 @@ if (($LifecycleRecommendations -or $LifecycleScan) -and $lifecycleEntries.Count 
                 @{ Marker = '-N';  Meaning = "Recommended SKU costs LESS than current, or has fewer resources (e.g. -10 = saves `$10/mo per VM)." }
                 @{ Marker = '0';   Meaning = "No change between current and recommended (price, vCPU, memory, disks, or IOPS)." }
                 @{ Marker = '-';   Meaning = "Data not available (capability missing from SKU index, or price unavailable for region)." }
-                @{ Marker = '✓ Zones N'; Meaning = "Recommended SKU is fully available in those availability zone(s) of the deployed region." }
-                @{ Marker = '⚠ Zones N'; Meaning = "Recommended SKU has LIMITED availability in those zone(s) — capacity-constrained or quota-restricted. Deployment may succeed but consider widening the region or alternate zones." }
+                @{ Marker = '✓ Zones N'; Meaning = "Recommended SKU returned no ARM restriction in those availability zone(s) of the deployed region." }
+                @{ Marker = '⚠ Zones N'; Meaning = "Recommended SKU returned LIMITED restriction/access signals in those zone(s). Verify placement or consider alternate zones." }
                 @{ Marker = '✗ Zones N'; Meaning = "Recommended SKU is RESTRICTED in those zone(s) — Microsoft has marked the SKU as unavailable for new deployments there. Choose a different zone or SKU." }
                 @{ Marker = 'Non-zonal'; Meaning = "Region or SKU does not advertise per-zone availability (regional deployment only)." }
                 @{ Marker = 'No alternatives'; Meaning = "No same-family or compatible-profile SKU was found in the scanned regions AND no Microsoft-documented upgrade path applies. Treat as HIGH risk — the workload may be locked to a retiring/constrained SKU. Widening -Regions scope often resolves this for SAP/HANA M-series and other niche families." }
-                @{ Marker = 'No alternatives in scanned regions (advisory only)'; Meaning = "Microsoft has a documented successor SKU for this family (shown in the Best-fit row with 'Advisory' capacity), but it is not deployable in any of the regions you scanned. Widen -Regions to include a region that offers the successor, or treat the advisory SKU as a planning target." }
+                @{ Marker = 'No alternatives in scanned regions (advisory only)'; Meaning = "Microsoft has a documented successor SKU for this family (shown in the Best-fit row with legacy Capacity value 'Advisory'), but it was not returned as an unrestricted option in any scanned region. Widen -Regions to include a region that offers the successor, or treat the advisory SKU as a planning target." }
                 @{ Marker = 'Advisory'; Meaning = "Recommendation is informational only — the SKU is Microsoft's documented successor (from data/UpgradePath.json) but was NOT found in any scanned region. Capability deltas, prices, and zones are unavailable. Use to identify migration targets; widen -Regions to validate deployability." }
             )
 
@@ -4466,11 +4470,11 @@ $script:OutputWidth = [Math]::Max($matrixWidth, $DefaultTerminalWidth)
 
 # Display section header with dynamic width
 Write-Host ("=" * $matrixWidth) -ForegroundColor Gray
-Write-Host "MULTI-REGION CAPACITY MATRIX" -ForegroundColor Green
+Write-Host "MULTI-REGION SKU RESTRICTION MATRIX" -ForegroundColor Green
 Write-Host ("=" * $matrixWidth) -ForegroundColor Gray
 Write-Host ""
-Write-Host "SUMMARY: Best-case status for each VM family (e.g., D, F, NC) per region." -ForegroundColor DarkGray
-Write-Host "This shows if ANY SKUs in the family are available - not all SKUs." -ForegroundColor DarkGray
+Write-Host "SUMMARY: Best-case ARM SKU restriction status for each VM family (e.g., D, F, NC) per region." -ForegroundColor DarkGray
+Write-Host "This shows if ANY SKUs in the family returned no restriction - not all SKUs." -ForegroundColor DarkGray
 Write-Host "For individual SKU details, see the detailed table above." -ForegroundColor DarkGray
 Write-Host ""
 
@@ -4506,22 +4510,23 @@ foreach ($family in ($allFamilyStats.Keys | Sort-Object)) {
 
 Write-Host ""
 Write-Host "HOW TO READ THIS:" -ForegroundColor Cyan
-Write-Host "  Green row  = At least one SKU in this family is fully available." -ForegroundColor Green
-Write-Host "  Yellow row = Some SKUs may work, but there are constraints." -ForegroundColor Yellow
-Write-Host "  Gray row   = No SKUs from this family available in scanned regions." -ForegroundColor Gray
+Write-Host "  Green row  = At least one SKU in this family returned no ARM restriction." -ForegroundColor Green
+Write-Host "  Yellow row = Some SKUs have ARM restriction signals or zone constraints." -ForegroundColor Yellow
+Write-Host "  Gray row   = No SKUs from this family were returned in scanned regions." -ForegroundColor Gray
 Write-Host ""
 Write-Host "STATUS MEANINGS:" -ForegroundColor Cyan
-Write-Host ("  $($Icons.OK)".PadRight(16) + "= Ready to deploy. No restrictions.") -ForegroundColor Green
-Write-Host ("  $($Icons.CAPACITY)".PadRight(16) + "= Azure is low on hardware. Try a different zone or wait.") -ForegroundColor Yellow
-Write-Host ("  $($Icons.LIMITED)".PadRight(16) + "= Your subscription can't use this. Request access via support ticket.") -ForegroundColor Yellow
-Write-Host ("  $($Icons.PARTIAL)".PadRight(16) + "= Some zones work, others are blocked. No zone redundancy.") -ForegroundColor Yellow
-Write-Host ("  $($Icons.BLOCKED)".PadRight(16) + "= Cannot deploy. Pick a different region or SKU.") -ForegroundColor Red
+Write-Host ("  $($Icons.OK)".PadRight(16) + "= No ARM SKU restriction returned for the scanned scope.") -ForegroundColor Green
+Write-Host ("  $($Icons.CAPACITY)".PadRight(16) + "= Some zones returned ARM restriction records; verify placement/deployment.") -ForegroundColor Yellow
+Write-Host ("  $($Icons.LIMITED)".PadRight(16) + "= Subscription/SKU access restriction; request access if needed.") -ForegroundColor Yellow
+Write-Host ("  $($Icons.PARTIAL)".PadRight(16) + "= Mixed zone restriction state; zone redundancy may be limited.") -ForegroundColor Yellow
+Write-Host ("  $($Icons.BLOCKED)".PadRight(16) + "= Blocking ARM restriction returned; pick another region or SKU.") -ForegroundColor Red
 Write-Host ""
-Write-Host "NOTE: 'OK' means SOME SKUs work, not ALL. Check the detailed table above" -ForegroundColor DarkYellow
-Write-Host "      for specific SKU availability (e.g., Standard_D4s_v5 vs Standard_D8s_v5)." -ForegroundColor DarkYellow
+Write-Host "NOTE: These labels are restriction metadata from Microsoft.Compute/skus, not a live" -ForegroundColor DarkYellow
+Write-Host "      hardware capacity check. Use -ShowPlacement, capacity reservation/probe, or" -ForegroundColor DarkYellow
+Write-Host "      deployment validation when allocation confidence matters." -ForegroundColor DarkYellow
 Write-Host ""
-Write-Host "NEED MORE CAPACITY?" -ForegroundColor Cyan
-Write-Host "  LIMITED status: Request quota increase at:" -ForegroundColor Yellow
+Write-Host "NEED ACCESS OR QUOTA?" -ForegroundColor Cyan
+Write-Host "  LIMITED status: request SKU access or quota review at:" -ForegroundColor Yellow
 # Use environment-aware portal URL
 $quotaPortalUrl = if ($script:AzureEndpoints -and $script:AzureEndpoints.EnvironmentName) {
     switch ($script:AzureEndpoints.EnvironmentName) {
@@ -4541,11 +4546,11 @@ if ($FetchPricing) {
 }
 
 #endregion Multi-Region Matrix
-#region Deployment Recommendations
+#region Deployment Planning Notes
 
 Write-Host "`n" -NoNewline
 Write-Host ("=" * $script:OutputWidth) -ForegroundColor Gray
-Write-Host "DEPLOYMENT RECOMMENDATIONS" -ForegroundColor Green
+Write-Host "DEPLOYMENT PLANNING NOTES" -ForegroundColor Green
 Write-Host ("=" * $script:OutputWidth) -ForegroundColor Gray
 Write-Host ""
 
@@ -4564,7 +4569,7 @@ foreach ($family in $allFamilyStats.Keys) {
 
 $hasBest = ($bestPerRegion.Values | Measure-Object -Property Count -Sum).Sum -gt 0
 if ($hasBest) {
-    Write-Host "Regions with full capacity:" -ForegroundColor Green
+    Write-Host "Regions with no returned ARM SKU restrictions for at least one scanned family:" -ForegroundColor Green
     foreach ($r in $allRegions) {
         $families = @($bestPerRegion[$r])
         if ($families.Count -gt 0) {
@@ -4574,8 +4579,8 @@ if ($hasBest) {
     }
 }
 else {
-    Write-Host "No regions have full capacity for the scanned families." -ForegroundColor Yellow
-    Write-Host "Best available options (with constraints):" -ForegroundColor Yellow
+    Write-Host "No scanned regions had fully unrestricted SKU-family status." -ForegroundColor Yellow
+    Write-Host "Best available options by returned restriction status:" -ForegroundColor Yellow
     foreach ($family in ($allFamilyStats.Keys | Sort-Object | Select-Object -First 5)) {
         $stats = $allFamilyStats[$family]
         $bestRegion = $stats.Regions.Keys | Sort-Object { $stats.Regions[$_].Available } -Descending | Select-Object -First 1
@@ -4587,7 +4592,7 @@ else {
     }
 }
 
-#endregion Deployment Recommendations
+#endregion Deployment Planning Notes
 #region Detailed Breakdown
 
 Write-Host "`n" -NoNewline
@@ -4595,7 +4600,7 @@ Write-Host ("=" * $script:OutputWidth) -ForegroundColor Gray
 Write-Host "DETAILED CROSS-REGION BREAKDOWN" -ForegroundColor Green
 Write-Host ("=" * $script:OutputWidth) -ForegroundColor Gray
 Write-Host ""
-Write-Host "SUMMARY: Shows which regions have capacity for each VM family." -ForegroundColor DarkGray
+Write-Host "SUMMARY: Shows returned ARM SKU restriction status for each VM family." -ForegroundColor DarkGray
 Write-Host "  'Available'   = At least one SKU in this family can be deployed here" -ForegroundColor DarkGray
 Write-Host "  'Constrained' = Family has issues in this region (see reason in parentheses)" -ForegroundColor DarkGray
 Write-Host "  '(none)'      = No regions in that category for this family" -ForegroundColor DarkGray
@@ -4790,8 +4795,8 @@ if ($ExportPath) {
             #region Add Compact Legend to Summary Sheet
             $legendStartRow = $lastRow + 3  # Leave 2 blank rows
 
-            # Legend title - Capacity Status
-            $ws.Cells["A$legendStartRow"].Value = "CAPACITY STATUS"
+            # Legend title - legacy Capacity column contains ARM restriction status
+            $ws.Cells["A$legendStartRow"].Value = "SKU RESTRICTION STATUS"
             $ws.Cells["A$legendStartRow`:C$legendStartRow"].Merge = $true
             $ws.Cells["A$legendStartRow"].Style.Font.Bold = $true
             $ws.Cells["A$legendStartRow"].Style.Font.Size = 11
@@ -4801,11 +4806,11 @@ if ($ExportPath) {
 
             # Status codes table
             $statusItems = @(
-                @{ Status = "OK"; Desc = "Ready to deploy. No restrictions." }
-                @{ Status = "LIMITED"; Desc = "Your subscription can't use this. Request access via support ticket." }
-                @{ Status = "CAPACITY-CONSTRAINED"; Desc = "Azure is low on hardware. Try a different zone or wait." }
-                @{ Status = "PARTIAL"; Desc = "Some zones work, others are blocked. No zone redundancy." }
-                @{ Status = "RESTRICTED"; Desc = "Cannot deploy. Pick a different region or SKU." }
+                @{ Status = "OK"; Desc = "No ARM SKU restriction returned for the scanned scope." }
+                @{ Status = "LIMITED"; Desc = "Subscription/SKU access restriction; request access if needed." }
+                @{ Status = "CAPACITY-CONSTRAINED"; Desc = "Some zones returned ARM restriction records; verify placement/deployment." }
+                @{ Status = "PARTIAL"; Desc = "Mixed zone restriction state; zone redundancy may be limited." }
+                @{ Status = "RESTRICTED"; Desc = "Blocking ARM restriction returned; pick another region or SKU." }
             )
 
             $currentRow = $legendStartRow + 1
@@ -4893,7 +4898,7 @@ if ($ExportPath) {
             $currentRow += 2
             $ws.Cells["A$currentRow"].Value = "FORMAT:"
             $ws.Cells["A$currentRow"].Style.Font.Bold = $true
-            $ws.Cells["B$currentRow"].Value = "STATUS (X/Y) = X SKUs available out of Y total"
+            $ws.Cells["B$currentRow"].Value = "STATUS (X/Y) = X SKUs with no returned restriction out of Y total"
             $currentRow++
             $ws.Cells["A$currentRow`:C$currentRow"].Merge = $true
             $ws.Cells["A$currentRow"].Value = "See 'Legend' tab for detailed column descriptions"
@@ -4963,20 +4968,20 @@ if ($ExportPath) {
 
             #region Legend Sheet
             $legendData = @(
-                [PSCustomObject]@{ Category = "STATUS FORMAT"; Item = "STATUS (X/Y)"; Description = "X = SKUs with full availability, Y = Total SKUs in family for that region" }
-                [PSCustomObject]@{ Category = "STATUS FORMAT"; Item = "Example: OK (5/8)"; Description = "5 out of 8 SKUs are fully available with OK status" }
+                [PSCustomObject]@{ Category = "STATUS FORMAT"; Item = "STATUS (X/Y)"; Description = "X = SKUs with no returned ARM restriction, Y = total SKUs in family for that region" }
+                [PSCustomObject]@{ Category = "STATUS FORMAT"; Item = "Example: OK (5/8)"; Description = "5 out of 8 SKUs returned no ARM restriction with OK status" }
                 [PSCustomObject]@{ Category = ""; Item = ""; Description = "" }
-                [PSCustomObject]@{ Category = "CAPACITY STATUS"; Item = "OK"; Description = "Ready to deploy. No restrictions." }
-                [PSCustomObject]@{ Category = "CAPACITY STATUS"; Item = "LIMITED"; Description = "Your subscription can't use this. Request access via support ticket." }
-                [PSCustomObject]@{ Category = "CAPACITY STATUS"; Item = "CAPACITY-CONSTRAINED"; Description = "Azure is low on hardware. Try a different zone or wait." }
-                [PSCustomObject]@{ Category = "CAPACITY STATUS"; Item = "PARTIAL"; Description = "Some zones work, others are blocked. No zone redundancy." }
-                [PSCustomObject]@{ Category = "CAPACITY STATUS"; Item = "RESTRICTED"; Description = "Cannot deploy. Pick a different region or SKU." }
-                [PSCustomObject]@{ Category = "CAPACITY STATUS"; Item = "N/A"; Description = "SKU family not available in this region." }
+                [PSCustomObject]@{ Category = "SKU RESTRICTION STATUS"; Item = "OK"; Description = "No ARM SKU restriction returned for the scanned scope. Not a live capacity guarantee." }
+                [PSCustomObject]@{ Category = "SKU RESTRICTION STATUS"; Item = "LIMITED"; Description = "Subscription/SKU access restriction; request access if needed." }
+                [PSCustomObject]@{ Category = "SKU RESTRICTION STATUS"; Item = "CAPACITY-CONSTRAINED"; Description = "Some zones returned ARM restriction records; verify placement/deployment." }
+                [PSCustomObject]@{ Category = "SKU RESTRICTION STATUS"; Item = "PARTIAL"; Description = "Mixed zone restriction state; zone redundancy may be limited." }
+                [PSCustomObject]@{ Category = "SKU RESTRICTION STATUS"; Item = "RESTRICTED"; Description = "Blocking ARM restriction returned; pick another region or SKU." }
+                [PSCustomObject]@{ Category = "SKU RESTRICTION STATUS"; Item = "N/A"; Description = "SKU family not returned in this region." }
                 [PSCustomObject]@{ Category = ""; Item = ""; Description = "" }
                 [PSCustomObject]@{ Category = "SUMMARY COLUMNS"; Item = "Family"; Description = "VM family identifier (e.g., Dv5, Ev5, Mv2)" }
                 [PSCustomObject]@{ Category = "SUMMARY COLUMNS"; Item = "Total_SKUs"; Description = "Total number of SKUs scanned across all regions" }
-                [PSCustomObject]@{ Category = "SUMMARY COLUMNS"; Item = "SKUs_OK"; Description = "Number of SKUs with full availability (OK status)" }
-                [PSCustomObject]@{ Category = "SUMMARY COLUMNS"; Item = "<Region>_Status"; Description = "Capacity status for that region with (Available/Total) count" }
+                [PSCustomObject]@{ Category = "SUMMARY COLUMNS"; Item = "SKUs_OK"; Description = "Number of SKUs with no returned ARM restriction (OK status)" }
+                [PSCustomObject]@{ Category = "SUMMARY COLUMNS"; Item = "<Region>_Status"; Description = "Restriction status for that region with (Unrestricted/Total) count" }
                 [PSCustomObject]@{ Category = ""; Item = ""; Description = "" }
                 [PSCustomObject]@{ Category = "DETAILS COLUMNS"; Item = "Family"; Description = "VM family identifier" }
                 [PSCustomObject]@{ Category = "DETAILS COLUMNS"; Item = "SKU"; Description = "Full SKU name (e.g., Standard_D2s_v5)" }
@@ -4984,14 +4989,14 @@ if ($ExportPath) {
                 [PSCustomObject]@{ Category = "DETAILS COLUMNS"; Item = "vCPU"; Description = "Number of virtual CPUs" }
                 [PSCustomObject]@{ Category = "DETAILS COLUMNS"; Item = "MemGiB"; Description = "Memory in GiB" }
                 [PSCustomObject]@{ Category = "DETAILS COLUMNS"; Item = "Zones"; Description = "Availability zones where SKU is available" }
-                [PSCustomObject]@{ Category = "DETAILS COLUMNS"; Item = "Capacity"; Description = "Current capacity status" }
-                [PSCustomObject]@{ Category = "DETAILS COLUMNS"; Item = "Restrictions"; Description = "Any restrictions or capacity messages" }
+                [PSCustomObject]@{ Category = "DETAILS COLUMNS"; Item = "Capacity"; Description = "Legacy field name containing ARM SKU restriction status" }
+                [PSCustomObject]@{ Category = "DETAILS COLUMNS"; Item = "Restrictions"; Description = "ARM SKU restriction reason codes and messages" }
                 [PSCustomObject]@{ Category = "DETAILS COLUMNS"; Item = "QuotaAvail"; Description = "Available vCPU quota for this family (Limit - Current Usage)" }
                 [PSCustomObject]@{ Category = ""; Item = ""; Description = "" }
-                [PSCustomObject]@{ Category = "COLOR CODING"; Item = "Green"; Description = "Ready to deploy. No restrictions." }
-                [PSCustomObject]@{ Category = "COLOR CODING"; Item = "Yellow/Orange"; Description = "Constrained. Check status for what to do next." }
-                [PSCustomObject]@{ Category = "COLOR CODING"; Item = "Red"; Description = "Cannot deploy. Pick a different region or SKU." }
-                [PSCustomObject]@{ Category = "COLOR CODING"; Item = "Gray"; Description = "Not available in this region." }
+                [PSCustomObject]@{ Category = "COLOR CODING"; Item = "Green"; Description = "No ARM SKU restriction returned; still validate quota and placement." }
+                [PSCustomObject]@{ Category = "COLOR CODING"; Item = "Yellow/Orange"; Description = "ARM restriction signal present; review status and zones." }
+                [PSCustomObject]@{ Category = "COLOR CODING"; Item = "Red"; Description = "Blocking ARM restriction returned; pick another region or SKU." }
+                [PSCustomObject]@{ Category = "COLOR CODING"; Item = "Gray"; Description = "Not returned in this region." }
             )
 
             $excel = $legendData | Export-Excel -Path $xlsxFile -WorksheetName "Legend" -AutoSize -Append -PassThru

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Inventory readiness: disclaimer reworded to match other surfaces
 - README: added "What This Tool Proves vs What It Does NOT" evidence model table
 - SKILL.md: description now says "restriction status" and "readiness signals"
+- **Clarified SKU status semantics across runtime output and docs** — console legends, inventory readiness text, Excel legends, README, lifecycle docs, and the Copilot skill now state that `OK` / `LIMITED` / `CAPACITY-CONSTRAINED` are derived from ARM `Microsoft.Compute/skus` restriction metadata. `OK` now means no ARM SKU restriction was returned for the scanned scope; it is not presented as a live physical capacity guarantee.
 
 ### Note
 - The `Capacity` field name and `CAPACITY-CONSTRAINED` status label are unchanged in this release
@@ -43,11 +44,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Serial scan path** — inlined `CpuArchitectureType` extraction to match parallel block pattern; unknown-arch SKUs now excluded (was defaulting to x64)
 - **CHANGELOG placement** — moved ArchFilter entry from premature `[2.3.0]` to `[Unreleased]` (corrected in this release)
 - **Docs accuracy** — removed hardcoded "39 parameters" from copilot-instructions.md; removed contributor scratch file
-
-## [Unreleased]
-
-### Changed
-- **Clarified SKU status semantics across runtime output and docs** — console legends, inventory readiness text, Excel legends, README, lifecycle docs, and the Copilot skill now state that `OK` / `LIMITED` / `CAPACITY-CONSTRAINED` are derived from ARM `Microsoft.Compute/skus` restriction metadata. `OK` now means no ARM SKU restriction was returned for the scanned scope; it is not presented as a live physical capacity guarantee.
 
 ### Fixed (docs)
 - **ROADMAP v2.2.2 blockquote accuracy (Copilot reviews on PR #154 and PR #156)** — corrected the description of `release-publish.yml`'s lint gate. Initial fix removed the inaccurate "reports PSScriptAnalyzer warnings via SARIF and only blocks on errors" wording (workflow has no SARIF emitter or `security-events: write` permission). Follow-up Copilot review on PR #156 (ID 3211981166) flagged the replacement "Error/Warning severity" wording as still inaccurate; final wording now reads "PSScriptAnalyzer with `-Severity Error` (only Error-severity findings block; uses shared `PSScriptAnalyzerSettings.psd1`)" — verified against `.github/workflows/release-publish.yml:47-48`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Clarified all user-facing status descriptions to state ARM restriction metadata, not capacity
+- Startup banner: "restriction status" language, explicit "NOT a live capacity or allocation guarantee"
+- Recommend mode header: "CAPACITY RECOMMENDER" → "SKU RECOMMENDER"
+- Recommend mode: "Available in:" → "Unrestricted in:", "better availability" → "fewer restrictions"
+- Status key legend: tightened OK, CAPACITY-CONSTRAINED, and NOTE descriptions
+- Excel legend: updated OK, CAPACITY-CONSTRAINED descriptions; Capacity column notes future rename
+- Help text (.DESCRIPTION): "availability" → "deployment readiness signals"
+- Inventory readiness: disclaimer reworded to match other surfaces
+- README: added "What This Tool Proves vs What It Does NOT" evidence model table
+- SKILL.md: description now says "restriction status" and "readiness signals"
+
+### Note
+- The `Capacity` field name and `CAPACITY-CONSTRAINED` status label are unchanged in this release
+- A future release will rename these — see GitHub Issues for timeline
+
 ## [2.3.1] - 2026-05-21
 
 ### Changed
@@ -27,6 +45,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Docs accuracy** — removed hardcoded "39 parameters" from copilot-instructions.md; removed contributor scratch file
 
 ## [Unreleased]
+
+### Changed
+- **Clarified SKU status semantics across runtime output and docs** — console legends, inventory readiness text, Excel legends, README, lifecycle docs, and the Copilot skill now state that `OK` / `LIMITED` / `CAPACITY-CONSTRAINED` are derived from ARM `Microsoft.Compute/skus` restriction metadata. `OK` now means no ARM SKU restriction was returned for the scanned scope; it is not presented as a live physical capacity guarantee.
 
 ### Fixed (docs)
 - **ROADMAP v2.2.2 blockquote accuracy (Copilot reviews on PR #154 and PR #156)** — corrected the description of `release-publish.yml`'s lint gate. Initial fix removed the inaccurate "reports PSScriptAnalyzer warnings via SARIF and only blocks on errors" wording (workflow has no SARIF emitter or `security-events: write` permission). Follow-up Copilot review on PR #156 (ID 3211981166) flagged the replacement "Error/Warning severity" wording as still inaccurate; final wording now reads "PSScriptAnalyzer with `-Severity Error` (only Error-severity findings block; uses shared `PSScriptAnalyzerSettings.psd1`)" — verified against `.github/workflows/release-publish.yml:47-48`.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A PowerShell tool for scanning Azure VM SKU restriction status, quota, pricing, 
 
 ## Overview
 
-Get-AzVMAvailability scans Azure regions for VM SKU restriction status, quota headroom, zone support, pricing, placement signals, and image compatibility. It helps you identify where ARM returns no blocking restrictions for your subscription and plan deployments accordingly.
+Get-AzVMAvailability scans Azure regions for VM SKU restriction status, quota headroom, zone support, pricing, placement signals, and image compatibility. It helps you identify where ARM returns no blocking restrictions for your subscription so you can plan deployments accordingly.
 
 ## Important Framing
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center">
-  <img src="assets/header-dark.png" alt="Get-AzVMAvailability — Discover Available Azure VM Capacity Across Regions" />
+  <img src="assets/header-dark.png" alt="Get-AzVMAvailability - Azure VM SKU restriction, quota, pricing, and placement signals" />
 </p>
 
-A PowerShell tool for checking Azure VM SKU availability across regions - find where your VMs can deploy.
+A PowerShell tool for scanning Azure VM SKU restriction status, quota, pricing, and placement signals across regions.
 
 ![PowerShell](https://img.shields.io/badge/PowerShell-7.0%2B-blue)
 ![Azure](https://img.shields.io/badge/Azure-Az%20Modules-0078D4)
@@ -11,7 +11,26 @@ A PowerShell tool for checking Azure VM SKU availability across regions - find w
 
 ## Overview
 
-Get-AzVMAvailability helps you identify which Azure regions have available capacity for your VM deployments. It scans multiple regions in parallel and provides detailed insights into SKU availability, zone restrictions, quota limits, pricing, and image compatibility.
+Get-AzVMAvailability scans Azure regions for VM SKU restriction status, quota headroom, zone support, pricing, placement signals, and image compatibility. It helps you identify where ARM returns no blocking restrictions for your subscription and plan deployments accordingly.
+
+## Important Framing
+
+The status labels come from the ARM `Microsoft.Compute/skus` API restriction metadata. `OK` means Azure did not return a blocking SKU restriction record for the scanned subscription, region, SKU, or zone. It does not prove live physical capacity, and deployment can still fail because of quota, allocation, policy, networking dependencies, or transient platform conditions.
+
+Use `-ShowPlacement`, capacity reservations/probes, or an actual deployment validation when you need stronger allocation confidence.
+
+### What This Tool Proves vs What It Does NOT
+
+| Signal | What It Tells You | What It Does NOT Tell You |
+|--------|-------------------|--------------------------|
+| **Restriction Status** (OK/LIMITED/etc.) | ARM returned no blocking SKU restriction for your subscription/region/zone | Whether Azure has physical hardware available right now |
+| **Quota Headroom** | How many vCPUs remain in your subscription quota | Whether those vCPUs can be allocated (quota ≠ capacity) |
+| **Zone Support** | Which availability zones the SKU is offered in | Whether those zones have allocatable capacity |
+| **Placement Score** | Spot VM allocation likelihood (High/Medium/Low) | Standard VM allocation likelihood |
+| **Pricing** | Retail or negotiated price per hour | Nothing about capacity |
+| **Image Compatibility** | Whether your image URN is compatible with the SKU | Nothing about capacity |
+
+> **The only ways to confirm actual capacity:** a successful deployment, a Capacity Reservation, or an internal Azure capacity signal.
 
 ## What's New
 
@@ -70,11 +89,11 @@ Get-AzVMAvailability helps you identify which Azure regions have available capac
 - **Image Compatibility** - Verify Gen1/Gen2 and x64/ARM64 requirements
 - **Zone Availability** - Per-zone availability details
 - **Quota Tracking** - Available vCPU quota per family
-- **Multi-Region Matrix** - Color-coded comparison view
+- **Multi-Region Matrix** - Color-coded comparison of returned ARM SKU restriction status
 - **Interactive Drill-Down** - Explore specific families and SKUs
 - **Export Options** - CSV and styled XLSX with conditional formatting
 - **JSON Output** - Structured JSON for AI agent integration and automation pipelines
-- **Inventory Readiness** - Validate capacity and quota for an entire VM BOM in one command
+- **Inventory Readiness** - Validate returned SKU restriction status and quota for an entire VM BOM in one command
 - **Compatibility-Validated Recommendations** - Alternatives are validated to meet or exceed the target SKU's NICs, accelerated networking, premium IO, disk interface, ephemeral OS disk, and Ultra SSD requirements. Data disks and IOPS are scored as soft dimensions
 
 ## Quick Comparison
@@ -82,7 +101,7 @@ Get-AzVMAvailability helps you identify which Azure regions have available capac
 | Task                           | Azure Portal            | This Script          |
 | ------------------------------ | ----------------------- | -------------------- |
 | Check 10 regions               | ~5 minutes              | ~15 seconds          |
-| Get quota + availability       | Multiple blades         | Single view          |
+| Get quota + restriction signal | Multiple blades         | Single view          |
 | Compare pricing across regions | Separate calculator     | Integrated           |
 | Filter to specific SKUs        | Scroll through hundreds | Wildcard filtering   |
 | Check image compatibility      | Manual research         | Automated validation |
@@ -92,10 +111,10 @@ Get-AzVMAvailability helps you identify which Azure regions have available capac
 ## Use Cases
 
 - **VM Lifecycle & Retirement Planning** - Identify old-gen and retiring SKUs across your fleet and get validated upgrade paths
-- **Disaster Recovery Planning** - Identify backup regions with capacity
-- **Multi-Region Deployments** - Find regions where all required SKUs are available
-- **GPU/HPC Workloads** - NC, ND, NV series are often constrained; find where they're available
-- **Inventory Readiness Validation** - Verify capacity and quota for an entire VM BOM before deployment
+- **Disaster Recovery Planning** - Identify backup regions with no returned SKU restrictions
+- **Multi-Region Deployments** - Find regions where required SKUs are offered and unrestricted by ARM metadata
+- **GPU/HPC Workloads** - NC, ND, NV series are often constrained; find where ARM returns them without blocking restrictions
+- **Inventory Readiness Validation** - Verify SKU restriction status and quota for an entire VM BOM before deployment
 - **Image Compatibility** - Verify SKUs support your Gen2 or ARM64 images before deployment
 - **Troubleshooting Deployments** - Quickly identify why a deployment might be failing
 


### PR DESCRIPTION
## Summary

Clarifies all user-facing text to explicitly state that status labels (OK, LIMITED, CAPACITY-CONSTRAINED, etc.) come from **ARM SKU restriction metadata**, not live physical capacity. No field renames, no schema changes, no breaking changes.

## Motivation

A downstream consumer (Jeff Pigott's Capacity Planning Dashboard) traced the REST calls and correctly identified that `Microsoft.Compute/skus` returns subscription/region/SKU restriction records, not live capacity signals. Our labels and docs in several places overstated what these signals prove — e.g., "Ready to deploy" for OK, "Azure is low on hardware" for CAPACITY-CONSTRAINED.

The raw data is correct. The presentation layer over-promised.

## What Changed

### Console & Display Text
- Startup banner: "restriction status" language, explicit "NOT a live capacity or allocation guarantee"
- Recommend mode header: "CAPACITY RECOMMENDER" → "SKU RECOMMENDER"
- "Available in:" → "Unrestricted in:"
- "better availability" → "fewer restrictions"
- Status key legend: tightened OK, CAPACITY-CONSTRAINED, and NOTE descriptions
- Inventory readiness disclaimer: reworded to match other surfaces

### Documentation
- README: rewrote overview, added "What This Tool Proves vs What It Does NOT" evidence model table
- Help text (.DESCRIPTION): "availability" → "deployment readiness signals"
- SKILL.md: description now says "restriction status" and "readiness signals"
- Excel legend: updated descriptions; Capacity column notes future rename

### CHANGELOG
- Added `[Unreleased]` section documenting all changes

## What Did NOT Change
- **No field renames** — `Capacity` property name unchanged
- **No status value changes** — `CAPACITY-CONSTRAINED` string unchanged
- **No schema version bump** — `schemaVersion` stays at `'1.0'`
- **No parameter changes** — all parameters identical
- **No behavioral changes** — output shape, JSON, CSV, Excel all identical

## Why Not Rename Fields Now?

A future release will rename `Capacity` → `RestrictionStatus` and `CAPACITY-CONSTRAINED` → `ZONE-LIMITED` with a schema version bump. This PR ships the safe, non-breaking wording fixes first. A GitHub Issue will be created post-merge to announce the upcoming rename.

## Validation
- 604/604 Pester tests pass
- 0 new PSScriptAnalyzer issues (7 pre-existing, none from these changes)
- Syntax, AI comment scan, version consistency, gh CLI patterns, module import — all pass

## Verification Checklist

### Verified Landmark Table

| Landmark / Claim | Evidence | Tag |
|---|---|---|
| Startup banner text updated | `Get-AzVMAvailability.ps1:1653-1655` — three Write-Host lines reworded | [OBSERVED] |
| Recommend header changed to SKU RECOMMENDER | `Write-RecommendOutputContract.ps1:19` — "CAPACITY RECOMMENDER" → "SKU RECOMMENDER" | [OBSERVED] |
| "Available in:" changed to "Unrestricted in:" | `Write-RecommendOutputContract.ps1:65` — Write-Host text updated | [OBSERVED] |
| "better availability" changed to "fewer restrictions" | `Write-RecommendOutputContract.ps1:159` — suggestion text updated | [OBSERVED] |
| Status key legend reworded | `Write-RecommendOutputContract.ps1:169-175` — 6 legend lines updated | [OBSERVED] |
| Excel legend descriptions updated | `Get-AzVMAvailability.ps1:4974-4996` — OK, CAPACITY-CONSTRAINED, Capacity column, Green color | [OBSERVED] |
| Help text .DESCRIPTION updated | `Get-AzVMAvailability.ps1:6-7` — "availability" → "deployment readiness signals" | [OBSERVED] |
| MinvCPU/MinMemoryGB help text updated | `Get-AzVMAvailability.ps1:114,118` — "better availability" → "fewer restrictions" | [OBSERVED] |
| Inventory disclaimer updated | `Write-InventoryReadinessSummary.ps1:25-26` — two Write-Host lines reworded | [OBSERVED] |
| README evidence model table added | `README.md` — new "What This Tool Proves vs What It Does NOT" section | [OBSERVED] |
| No field renames in this PR | Searched for property assignments — `Capacity` field name unchanged in output contracts | [SEARCHED] |
| No schema version change | `schemaVersion` remains `'1.0'` in all output contracts | [SEARCHED] |
| 604 Pester tests pass | `Validate-Script.ps1` run locally, 604/604 pass | [OBSERVED] |

### Behavior Parity

- **No output property changes** — `Capacity` field name, status string values (OK, LIMITED, CAPACITY-CONSTRAINED, RESTRICTED), and JSON schema are all identical to main
- **No parameter changes** — all parameter names, types, defaults, aliases, and validation attributes unchanged
- **No JSON schema changes** — `schemaVersion` remains `'1.0'`; all field names in `New-ScanOutputContract` and `New-RecommendOutputContract` unchanged
- **Console-only text changes** — all modifications are to `Write-Host` display text, help comments, and markdown documentation

## Quality Checklist

- [x] `Validate-Script.ps1` passes (604/604 tests, 0 new analyzer issues)
- [x] No new parameters, fields, or schema changes
- [x] CHANGELOG updated with `[Unreleased]` section
- [x] README updated with evidence model table
- [x] All commits are atomic (one logical change per commit)
- [x] No files deleted
- 0 new PSScriptAnalyzer issues (7 pre-existing, none from these changes)
- Syntax, AI comment scan, version consistency, gh CLI patterns, module import — all pass
