### PR TITLE
test: preserve ExportRow regression test from #171 (credit @opsmax)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Regression test `tests/ExportRow.Tests.ps1`** covering the per-family `$exportRow` `SKUs_OK` value expression. The test extracts the live expression from the public function via AST and evaluates it against mock per-region stats, and asserts the extracted expression contains no nested `function Get-AzVMAvailability` definition — a second, independent guard against the v3.0.0 duplication signature alongside `Validate-Script.ps1` check 8. Test authored by @opsmax in PR #171.
+
 ## [3.0.1] - 2026-08-03
 
 _Auto-published from changes since v3.0.0._

--- a/artifacts/copilot-review-log.md
+++ b/artifacts/copilot-review-log.md
@@ -103,3 +103,11 @@
 **Assessment:** Agree
 **Reasoning:** Verified directly. `Tags`, `LicenseUri`, and `ProjectUri` are indented 12 spaces inside the `PSData` hashtable; `ReleaseNotes` was at 8. Root cause is `.github/workflows/auto-publish.yml` line 282, where `\` hardcodes an 8-space prefix. Because the regex `(?m)^\s*ReleaseNotes\s*=\s*'[^']+'` consumes the leading whitespace, the replacement string fully controls indentation, so every auto-published release would reintroduce the same misalignment.
 **Action taken:** Corrected the indentation to 12 spaces in the manifest AND fixed the generator in `auto-publish.yml` so the defect does not recur. The 12-space form also naturally aligns the `=` with the sibling keys.
+
+## PR #177 - test/exportrow-regression-170 - branch commit for ExportRow test
+
+**File:** `tests/ExportRow.Tests.ps1:33`
+**Copilot finding:** "The parse-failure exception omits the target file path, which makes failures harder to diagnose in CI logs (especially when multiple AST parses happen in the suite). Include `\` in the thrown message (similar to tests/TestHarness.psm1)."
+**Assessment:** Agree
+**Reasoning:** Verified. The throw read `"Public file failed to parse: $messages"` with no path. Multiple test files in this suite parse module files via AST, so a bare parse-failure message is ambiguous in CI output. `tests/TestHarness.psm1` already includes the path in comparable errors, so this also aligns the new file with existing convention. Low risk - the change touches only an error string on a path that is not exercised when the module parses cleanly.
+**Action taken:** Changed the throw to `"Public file failed to parse: $publicFile :: $messages"`. Full validation re-run: 8/8 checks PASS, 611 tests pass, exit 0.

--- a/tests/ExportRow.Tests.ps1
+++ b/tests/ExportRow.Tests.ps1
@@ -1,0 +1,147 @@
+# ExportRow.Tests.ps1
+# Pester regression tests for the per-family $exportRow construction inside
+# Get-AzVMAvailability (issue #170).
+#
+# The bug: the SKUs_OK value expression inside the per-family $exportRow hashtable
+# - a Where-Object pipeline over $stats.Regions.Values - was malformed in v3.0.0,
+# causing the export pipeline to crash at runtime with
+# "'.RestrictionStatus' is not recognized as a name of a cmdlet".
+#
+# These tests extract the actual SKUs_OK value expression from the production
+# module file via AST, then execute it against a mock $stats input and assert
+# that it returns the correct OK-count. A regression of the v3.0.0 corruption
+# would either fail the AST extraction or fail at runtime - either way the
+# test fails.
+#
+# Run with: Invoke-Pester ./tests/ExportRow.Tests.ps1 -Output Detailed
+
+BeforeAll {
+    $publicFile = Join-Path $PSScriptRoot '..' 'AzVMAvailability' 'Public' 'Get-AzVMAvailability.ps1'
+    if (-not (Test-Path -LiteralPath $publicFile)) {
+        throw "Public function file not found: $publicFile"
+    }
+    $publicFile = (Resolve-Path -LiteralPath $publicFile).Path
+
+    $parseErrors = $null
+    $parsedTokens = $null
+    $publicAst = [System.Management.Automation.Language.Parser]::ParseFile(
+        $publicFile, [ref]$parsedTokens, [ref]$parseErrors)
+
+    if ($parseErrors -and $parseErrors.Count -gt 0) {
+        $messages = ($parseErrors | ForEach-Object { $_.Message }) -join '; '
+        throw "Public file failed to parse: $messages"
+    }
+
+    # Find every hashtable in the public file that contains an 'SKUs_OK' key.
+    # In the correct file there is exactly one such site (the per-family
+    # $exportRow construction); finding more or fewer indicates a structural
+    # change worth a manual review.
+    $skusOkHashtables = $publicAst.FindAll(
+        {
+            param($node)
+            ($node -is [System.Management.Automation.Language.HashtableAst]) -and
+            (@($node.KeyValuePairs | Where-Object {
+                $_.Item1 -is [System.Management.Automation.Language.StringConstantExpressionAst] -and
+                $_.Item1.Value -eq 'SKUs_OK'
+            }).Count -gt 0)
+        },
+        $true
+    )
+
+    $script:SkusOkHashtableCount = @($skusOkHashtables).Count
+
+    if ($script:SkusOkHashtableCount -eq 1) {
+        $kvp = $skusOkHashtables[0].KeyValuePairs | Where-Object {
+            $_.Item1 -is [System.Management.Automation.Language.StringConstantExpressionAst] -and
+            $_.Item1.Value -eq 'SKUs_OK'
+        } | Select-Object -First 1
+        $script:SkusOkExprText = $kvp.Item2.Extent.Text
+        # Wrap with an explicit param so $stats is a declared input (avoids
+        # PSUseDeclaredVarsMoreThanAssignments warnings in callers) and makes
+        # the contract of the extracted expression visible. The newline
+        # between the param block and the extracted text ensures they parse
+        # as separate statements even if the extracted text ever starts with
+        # a leading comment or statement separator.
+        $script:SkusOkScript = [scriptblock]::Create("param(`$stats)`n$($script:SkusOkExprText)")
+    }
+    else {
+        # Either 0 sites (AST extraction failed) or 2+ sites (structural
+        # change in the public file). In both cases we cannot safely pick
+        # a single site to evaluate; leave the extracted artifacts null and
+        # let the AST-extraction count assertion + the runtime-context guard
+        # fail with their explicit messages.
+        $script:SkusOkExprText = $null
+        $script:SkusOkScript = $null
+    }
+}
+
+Describe "Per-family exportRow SKUs_OK expression (regression for #170)" {
+
+    Context "AST extraction" {
+
+        It "Finds exactly one SKUs_OK hashtable site in the public function" {
+            $script:SkusOkHashtableCount | Should -Be 1
+        }
+
+        It "Extracted value expression references RestrictionStatus" {
+            $script:SkusOkExprText | Should -Not -BeNullOrEmpty
+            $script:SkusOkExprText | Should -Match '\bRestrictionStatus\b'
+        }
+
+        It "Extracted value expression references Measure-Object summing Available" {
+            $script:SkusOkExprText | Should -Match '\bMeasure-Object\b'
+            $script:SkusOkExprText | Should -Match '\bAvailable\b'
+        }
+
+        It "Extracted value expression does not contain a nested function definition (corruption signature)" {
+            $script:SkusOkExprText | Should -Not -Match 'function\s+Get-AzVMAvailability'
+        }
+    }
+
+    Context "Runtime evaluation against mock per-region stats" {
+
+        BeforeAll {
+            # Guard: if AST extraction in the outer BeforeAll failed, fail this
+            # context fast with an actionable message instead of letting each It
+            # block produce a confusing 'cannot invoke null scriptblock' error.
+            if ($null -eq $script:SkusOkScript) {
+                throw "Runtime tests cannot run: SKUs_OK expression was not extracted from the public file. See AST extraction failures above."
+            }
+        }
+
+        It "Returns the sum of Available across regions whose RestrictionStatus is OK" {
+            $stats = [PSCustomObject]@{
+                Regions = @{
+                    'eastus'  = [PSCustomObject]@{ RestrictionStatus = 'OK';      Available = 3; Count = 5 }
+                    'westus2' = [PSCustomObject]@{ RestrictionStatus = 'LIMITED'; Available = 7; Count = 7 }
+                    'westeu'  = [PSCustomObject]@{ RestrictionStatus = 'OK';      Available = 2; Count = 2 }
+                }
+            }
+            $result = & $script:SkusOkScript -stats $stats
+            $result | Should -Be 5
+        }
+
+        It "Returns 0 or null when no region has RestrictionStatus OK (Measure-Object empty-pipeline semantics; PS-version-tolerant)" {
+            $stats = [PSCustomObject]@{
+                Regions = @{
+                    'eastus'  = [PSCustomObject]@{ RestrictionStatus = 'LIMITED';      Available = 1; Count = 1 }
+                    'westus2' = [PSCustomObject]@{ RestrictionStatus = 'ZONE-LIMITED'; Available = 4; Count = 4 }
+                }
+            }
+            $result = & $script:SkusOkScript -stats $stats
+            # Measure-Object on an empty filtered pipeline emits a Measurement
+            # object whose .Sum is $null on current PowerShell versions; allow
+            # 0 too in case that ever changes (per PR #171 review feedback).
+            $result | Should -BeIn @($null, 0)
+        }
+
+        It "Does not throw when given a well-formed stats input (issue #170 reproduction check)" {
+            $stats = [PSCustomObject]@{
+                Regions = @{
+                    'eastus' = [PSCustomObject]@{ RestrictionStatus = 'OK'; Available = 1; Count = 1 }
+                }
+            }
+            { & $script:SkusOkScript -stats $stats } | Should -Not -Throw
+        }
+    }
+}

--- a/tests/ExportRow.Tests.ps1
+++ b/tests/ExportRow.Tests.ps1
@@ -29,7 +29,7 @@ BeforeAll {
 
     if ($parseErrors -and $parseErrors.Count -gt 0) {
         $messages = ($parseErrors | ForEach-Object { $_.Message }) -join '; '
-        throw "Public file failed to parse: $messages"
+        throw "Public file failed to parse: $publicFile :: $messages"
     }
 
     # Find every hashtable in the public file that contains an 'SKUs_OK' key.


### PR DESCRIPTION
## Summary

Preserves the regression test authored by **@opsmax** in #171. That PR's code fix was superseded by the v3.0.1 de-duplication remediation, but the test itself is independently valuable and passes against current `main`.

Test-only change. No module code, parameters, or output schemas are touched.

### Why keep this test

The test extracts the **live** `SKUs_OK` value expression out of the public function via AST and evaluates it against mock per-region stats — so it verifies the production expression rather than a copy of it. One assertion is a direct guard against the v3.0.0 duplication signature:

```powershell
It "Extracted value expression does not contain a nested function definition (corruption signature)" {
    $script:SkusOkExprText | Should -Not -Match 'function\s+Get-AzVMAvailability'
}
```

That gives us a second, independent detector for the exact defect class that caused v3.0.0, alongside `Validate-Script.ps1` check 8.

Original commit authorship is preserved via `git commit --author` plus a `Co-authored-by:` trailer.

## Verification Checklist

### Verified Landmark Table

| Landmark / Claim | Evidence (file + how verified) | Tag |
|---|---|---|
| Test file is 147 lines and was the only file in the initial commit | git commit showed `1 file changed, 147 insertions(+)`; `create mode 100644 tests/ExportRow.Tests.ps1` | [OBSERVED] |
| Test passes on current main under CI-pinned Pester 5.7.1 | Ran `Invoke-Pester ./tests/ExportRow.Tests.ps1` against Pester 5.7.1 module path — `Passed=7 Failed=0 Skipped=0` | [OBSERVED] |
| Test passes on current main under Pester 6.0.0 | Ran same file under Pester 6.0.0 — `Tests Passed: 7, Failed: 0, Skipped: 0` | [OBSERVED] |
| Suite total rises 604 to 611 with no failures | `Validate-Script.ps1` check 3 reported 604 tests on the v3.0.1 branch and 611 tests on this branch | [OBSERVED] |
| Full validation passes 8 of 8 checks with exit code 0 | `tools/Validate-Script.ps1` — `ALL CHECKS PASSED`, `EXIT=0` | [OBSERVED] |
| SKUs_OK expression the test targets exists once in the public function | `Select-String -Pattern 'SKUs_OK'` on `AzVMAvailability/Public/Get-AzVMAvailability.ps1` returns one construction site plus one unrelated help-text row | [OBSERVED] |
| Git authorship is attributed to opsmax, not the committer | `git log --format` on the test-adding commit shows `author: opsmax <255807610+opsmax@users.noreply.github.com>`, `committer: Zachary Luz` | [OBSERVED] |
| Co-authored-by trailer is present on that commit | `git log --format="%(trailers)"` returns `Co-authored-by: opsmax <255807610+opsmax@users.noreply.github.com>` | [OBSERVED] |
| CHANGELOG has an `[Unreleased]` entry as the metadata guard requires | `### Added` bullet added under `## [Unreleased]` in `CHANGELOG.md` | [OBSERVED] |

### Behavior Parity

- [x] No parameters, aliases, defaults, or validation attributes changed
- [x] No change to the JSON schema emitted by `-JsonOutput`
- [x] No change to CSV/XLSX export column names or shapes
- [x] No change to prompting, error, or throw/return semantics
- [x] Test-only addition — no file under `AzVMAvailability/` is modified

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Code quality (refactoring, comments, tests — no behavior change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Quality Checklist

- [x] **PR markdown renders correctly** — no literal escaped newline sequences in title or body
- [x] **No AI instructional comments** — `Validate-Script.ps1` check 4 PASS
- [x] **No empty catch blocks** — the test adds no catch blocks
- [x] **No magic numbers** — only small mock-data integers inside test fixtures, self-evident in context
- [x] **Version strings in sync** — `Validate-Script.ps1` check 5 reports all references match v3.0.1; this PR does not touch any version string
- [x] **PSScriptAnalyzer clean** — check 2 PASS, 66 files checked, no warnings or errors
- [x] **Pester tests pass** — 611 passed, 0 failed
- [x] **Syntax valid** — check 1 PASS
- [x] **New functions have Pester test coverage** — N/A; this PR adds no functions, it adds tests
- [x] **CHANGELOG.md updated** — `### Added` entry under `## [Unreleased]` crediting @opsmax
- [x] **Release/tag plan prepared for this version bump** — N/A; `ScriptVersion` and `ModuleVersion` are unchanged at v3.0.1, so no tag or release is produced by this PR

## Validation

- [x] Ran `tools/Validate-Script.ps1` — 8 of 8 checks PASS, exit code 0
- [x] Test verified against both the CI-pinned Pester 5.x line and Pester 6.x

## Credit

Test authored by @opsmax (originally submitted in #171, filed against #170).
