### PR TITLE
fix(tools): restore ConvertTo-SafeJsonArray in dashboard generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Restored `ConvertTo-SafeJsonArray` in `tools/Generate-TrafficDashboard-Premium-v2.ps1`.** Piping an empty array to `ConvertTo-Json -AsArray` emits nothing at all, because the pipeline never delivers an element for `-AsArray` to act on. These values are interpolated directly into the dashboard's JavaScript, so an empty result produced `labels: ,` — a syntax error that blanks the entire dashboard. Any of the referrer, path, PSGallery, star, or view arrays can legitimately be empty on a fresh repo. The two downstream repos already carried this helper; without it, `sync-traffic-infra.yml` would have overwritten their working copies with the broken version.
+
 ## [3.0.2] - 2026-08-03
 
 _Auto-published from changes since v3.0.1._

--- a/artifacts/copilot-review-log.md
+++ b/artifacts/copilot-review-log.md
@@ -128,3 +128,17 @@
 **Copilot finding:** None. Review state APPROVED, body reports "Comments generated: 0".
 **Assessment:** N/A - no findings to triage.
 **Action taken:** None required. Major-version action bump accepted on the evidence that both Pester suites (ubuntu-latest and windows-latest) exercise the updated checkout action end to end and passed on the rebased head.
+
+## PR #181 - fix/dashboard-empty-json-array - commit 422bc53
+
+**File:** `tools/Generate-TrafficDashboard-Premium-v2.ps1:92`
+**Copilot finding:** "The #region header still says it is using @() to guarantee arrays for ConvertTo-Json, but this block now relies on ConvertTo-SafeJsonArray to guarantee `[]` on empty input. Updating the header will keep the comment accurate for future maintenance."
+**Assessment:** Agree
+**Reasoning:** Correct and worth fixing. The header read "Build JSON - use @() to guarantee arrays for ConvertTo-Json", which described the exact mechanism this PR replaced because it does not work: `@()` guarantees an array in PowerShell, but piping that array to `ConvertTo-Json -AsArray` still emits nothing when it is empty. Leaving the header would assert the failed approach as the current one, which is the comment-rot pattern the project explicitly guards against.
+**Action taken:** Changed the header to "Build JSON - ConvertTo-SafeJsonArray guarantees a literal [] on empty input". Re-ran full validation: 8/8 checks PASS, 611 tests, exit 0.
+
+**Reviewer:** sourcery-ai (PR-level comment, not an inline thread)
+**Finding:** "ConvertTo-SafeJsonArray assumes `\` is non-null; consider defensively handling `\` input (e.g., treating it as an empty array) to avoid potential .Count access errors if future callers change."
+**Assessment:** Disagree
+**Reasoning:** Tested rather than assumed, on PowerShell 7.6.4. The `[array]` parameter cast turns `\` into `\`, and `\.Count` returns `0` in PowerShell 3.0+ instead of throwing. All three null-passing forms were exercised - positional `\`, named `-Data \`, and omitting the parameter entirely - and each returned `'[]'` with no error. The described `.Count` access error is therefore not reachable. Adding a guard would be error handling for an impossible scenario, which the project's Simplicity First rule prohibits. Every call site also wraps its argument in `@()`, so a null can never reach the parameter in practice.
+**Action taken:** None. Replied on the PR with the test results so the reasoning is visible to future reviewers.

--- a/artifacts/copilot-review-log.md
+++ b/artifacts/copilot-review-log.md
@@ -111,3 +111,20 @@
 **Assessment:** Agree
 **Reasoning:** Verified. The throw read `"Public file failed to parse: $messages"` with no path. Multiple test files in this suite parse module files via AST, so a bare parse-failure message is ambiguous in CI output. `tests/TestHarness.psm1` already includes the path in comparable errors, so this also aligns the new file with existing convention. Low risk - the change touches only an error string on a path that is not exercised when the module parses cleanly.
 **Action taken:** Changed the throw to `"Public file failed to parse: $publicFile :: $messages"`. Full validation re-run: 8/8 checks PASS, 611 tests pass, exit 0.
+
+## PRs #180, #173, #172 - Copilot review outcomes (batch entry)
+
+**PR #180** (`chore/auto-publish-3.0.2` @ `1dd1f46`) - bot exemption for `release-metadata-guard.yml` + changelog blurb placement fix in `auto-publish.yml`.
+**Copilot finding:** None. Review body: "Copilot reviewed 9 out of 9 changed files in this pull request and generated no comments."
+**Assessment:** N/A - no findings to triage.
+**Action taken:** None required. Sourcery also reviewed with no issues. Merged after code-owner approval with 12/12 checks green and 0 unresolved threads.
+
+**PR #173** (`dependabot/github_actions/actions-minor-patch-83bd6e4a5a` @ `f981faa4`) - `github/codeql-action` 4 -> 4.37.4.
+**Copilot finding:** None. Review state COMMENTED with no inline comments.
+**Assessment:** N/A - no findings to triage.
+**Action taken:** None required. This PR was also the first verification that the new bot exemption works: its `Release Metadata Guard` check went from FAILURE (pre-fix) to SUCCESS (post-fix).
+
+**PR #172** (`dependabot/github_actions/actions/checkout-7` @ `2f2dc8ce`) - `actions/checkout` 6 -> 7 across 9 workflows.
+**Copilot finding:** None. Review state APPROVED, body reports "Comments generated: 0".
+**Assessment:** N/A - no findings to triage.
+**Action taken:** None required. Major-version action bump accepted on the evidence that both Pester suites (ubuntu-latest and windows-latest) exercise the updated checkout action end to end and passed on the rebased head.

--- a/tools/Generate-TrafficDashboard-Premium-v2.ps1
+++ b/tools/Generate-TrafficDashboard-Premium-v2.ps1
@@ -90,20 +90,31 @@ Write-Host "Loaded: $($views.Count) view days, $($clones.Count) clone days, $($s
 #endregion
 
 #region Build JSON — use @() to guarantee arrays for ConvertTo-Json
-$viewDates    = @($views  | ForEach-Object { $_.Date })            | ConvertTo-Json -Compress -AsArray
-$viewTotals   = @($views  | ForEach-Object { [int]$_.TotalViews }) | ConvertTo-Json -Compress -AsArray
-$viewUniques  = @($views  | ForEach-Object { [int]$_.UniqueViews })| ConvertTo-Json -Compress -AsArray
+# Piping an empty array to ConvertTo-Json emits nothing at all (the pipeline never
+# delivers an element, so -AsArray never fires). These values are interpolated
+# directly into the emitted JavaScript, so a $null here produces `labels: ,` —
+# a syntax error that blanks the whole dashboard. Any of these arrays can be
+# empty on a fresh repo or one with no referrer/PSGallery data yet.
+function ConvertTo-SafeJsonArray {
+    param([array]$Data)
+    if ($Data.Count -eq 0) { return '[]' }
+    return $Data | ConvertTo-Json -Compress -AsArray
+}
 
-$cloneDates   = @($clones | ForEach-Object { $_.Date })             | ConvertTo-Json -Compress -AsArray
-$cloneTotals  = @($clones | ForEach-Object { [int]$_.TotalClones }) | ConvertTo-Json -Compress -AsArray
-$cloneUniques = @($clones | ForEach-Object { [int]$_.UniqueClones })| ConvertTo-Json -Compress -AsArray
+$viewDates    = ConvertTo-SafeJsonArray @($views  | ForEach-Object { $_.Date })
+$viewTotals   = ConvertTo-SafeJsonArray @($views  | ForEach-Object { [int]$_.TotalViews })
+$viewUniques  = ConvertTo-SafeJsonArray @($views  | ForEach-Object { [int]$_.UniqueViews })
 
-$starDates      = @($stars | ForEach-Object { $_.Date })               | ConvertTo-Json -Compress -AsArray
-$starCumulative = @($stars | ForEach-Object { [int]$_.CumulativeStars })| ConvertTo-Json -Compress -AsArray
-$starUsers      = @($stars | ForEach-Object { $_.User })               | ConvertTo-Json -Compress -AsArray
+$cloneDates   = ConvertTo-SafeJsonArray @($clones | ForEach-Object { $_.Date })
+$cloneTotals  = ConvertTo-SafeJsonArray @($clones | ForEach-Object { [int]$_.TotalClones })
+$cloneUniques = ConvertTo-SafeJsonArray @($clones | ForEach-Object { [int]$_.UniqueClones })
 
-$psGalleryDates   = @($psGallery | ForEach-Object { $_.Date })                | ConvertTo-Json -Compress -AsArray
-$psGalleryTotalDl = @($psGallery | ForEach-Object { [long]$_.TotalDownloads })| ConvertTo-Json -Compress -AsArray
+$starDates      = ConvertTo-SafeJsonArray @($stars | ForEach-Object { $_.Date })
+$starCumulative = ConvertTo-SafeJsonArray @($stars | ForEach-Object { [int]$_.CumulativeStars })
+$starUsers      = ConvertTo-SafeJsonArray @($stars | ForEach-Object { $_.User })
+
+$psGalleryDates   = ConvertTo-SafeJsonArray @($psGallery | ForEach-Object { $_.Date })
+$psGalleryTotalDl = ConvertTo-SafeJsonArray @($psGallery | ForEach-Object { [long]$_.TotalDownloads })
 
 # Build release annotations from actual GitHub release publish dates
 $releaseAnnotations = @($releases | ForEach-Object {
@@ -112,14 +123,14 @@ $releaseAnnotations = @($releases | ForEach-Object {
         version = $_.TagName
     }
 })
-$releasesJson = $releaseAnnotations | ConvertTo-Json -Compress -AsArray
+$releasesJson = ConvertTo-SafeJsonArray $releaseAnnotations
 
-$refLabels  = @($referrers | ForEach-Object { $_.Referrer })           | ConvertTo-Json -Compress -AsArray
-$refViews   = @($referrers | ForEach-Object { [int]$_.TotalViews })    | ConvertTo-Json -Compress -AsArray
-$refUniques = @($referrers | ForEach-Object { [int]$_.UniqueVisitors }) | ConvertTo-Json -Compress -AsArray
+$refLabels  = ConvertTo-SafeJsonArray @($referrers | ForEach-Object { $_.Referrer })
+$refViews   = ConvertTo-SafeJsonArray @($referrers | ForEach-Object { [int]$_.TotalViews })
+$refUniques = ConvertTo-SafeJsonArray @($referrers | ForEach-Object { [int]$_.UniqueVisitors })
 
-$pathLabels = @($paths | ForEach-Object { $_.Path -replace '^/ZacharyLuz/Get-AzVMAvailability', '' -replace '^$', '/' }) | ConvertTo-Json -Compress -AsArray
-$pathViews  = @($paths | ForEach-Object { [int]$_.TotalViews }) | ConvertTo-Json -Compress -AsArray
+$pathLabels = ConvertTo-SafeJsonArray @($paths | ForEach-Object { $_.Path -replace '^/ZacharyLuz/Get-AzVMAvailability', '' -replace '^$', '/' })
+$pathViews  = ConvertTo-SafeJsonArray @($paths | ForEach-Object { [int]$_.TotalViews })
 
 # All-time totals (default to 0 when arrays are empty)
 $totalViewsAllTime  = if ($views.Count -gt 0) { ($views  | ForEach-Object { [int]$_.TotalViews }  | Measure-Object -Sum).Sum } else { 0 }

--- a/tools/Generate-TrafficDashboard-Premium-v2.ps1
+++ b/tools/Generate-TrafficDashboard-Premium-v2.ps1
@@ -89,7 +89,7 @@ if (Test-Path $pathsPath) {
 Write-Host "Loaded: $($views.Count) view days, $($clones.Count) clone days, $($stars.Count) stars, $($referrers.Count) referrers, $($paths.Count) paths, $(@($releaseDownloads).Count) release download snapshots, $($releases.Count) releases, $($psGallery.Count) PSGallery snapshots" -ForegroundColor Cyan
 #endregion
 
-#region Build JSON — use @() to guarantee arrays for ConvertTo-Json
+#region Build JSON — ConvertTo-SafeJsonArray guarantees a literal [] on empty input
 # Piping an empty array to ConvertTo-Json emits nothing at all (the pipeline never
 # delivers an element, so -AsArray never fires). These values are interpolated
 # directly into the emitted JavaScript, so a $null here produces `labels: ,` —


### PR DESCRIPTION
## Summary

Restores the `ConvertTo-SafeJsonArray` helper in the traffic dashboard generator, and lands the accumulated Copilot review triage log.

Found while reviewing the sync PRs that `sync-traffic-infra.yml` opened in the two downstream repos after its token was rotated. The sync diff **removed** this helper from those repos — they had it, this repo never did. Merging those PRs unchanged would have pushed the defect downstream.

### The bug

Piping an empty array to `ConvertTo-Json -AsArray` emits nothing at all: the pipeline never delivers an element, so `-AsArray` never fires. These values are interpolated directly into the dashboard's JavaScript:

```powershell
$refLabels = @($referrers | ForEach-Object { $_.Referrer }) | ConvertTo-Json -Compress -AsArray
```
```javascript
var refData = { labels: $refLabels, views: $refViews };
```

With no referrer data that emits `var refData = { labels: , views:  };` — a syntax error that blanks the whole dashboard. The referrer, path, PSGallery, star, view, clone, and release arrays can all legitimately be empty on a fresh or low-traffic repo.

## Verification Checklist

### Verified Landmark Table

| Landmark / Claim | Evidence (file + how verified) | Tag |
|---|---|---|
| Empty array piped to ConvertTo-Json -AsArray returns null, not `[]` | Ran the raw pipeline form against an empty array on PowerShell 7.6.4 — result was null with length 0 | [OBSERVED] |
| The helper returns `[]` for the same input | Ran the helper against the same empty input — returned the two-character string `[]` | [OBSERVED] |
| Both forms agree on non-empty input | Single-element input returned `["2026-01-01"]` from both the raw pipeline and the helper | [OBSERVED] |
| Without the fix the emitted JavaScript is invalid | Simulated the interpolation with empty arrays — produced `var refData = { labels: , views:  };` | [OBSERVED] |
| With the fix the emitted JavaScript is valid | Same simulation after the change — produced `var refData = { labels: [], views: [] };` | [OBSERVED] |
| The helper never existed in this repo | `git log -S 'ConvertTo-SafeJsonArray' -- tools/Generate-TrafficDashboard-Premium-v2.ps1` returned no commits | [OBSERVED] |
| The downstream repos do have it, and the sync would remove it | Sync PR diffs in Get-AzAIModelAvailability #11 and Get-AzPaaSAvailability #15 show the helper and its call sites among the removed lines | [OBSERVED] |
| No raw pipe-to-ConvertTo-Json call sites remain | `Select-String` for the raw pipeline form in the generator returned no matches | [OBSERVED] |
| The file still parses | `[Parser]::ParseFile` reported 0 errors | [OBSERVED] |
| Full validation passes | `tools/Validate-Script.ps1` — 8 of 8 checks PASS, 611 tests, exit code 0 | [OBSERVED] |

### Behavior Parity

- [x] No parameters, aliases, defaults, or validation attributes changed
- [x] No change to the JSON schema emitted by `-JsonOutput`
- [x] No change to CSV/XLSX export column names or shapes
- [x] No change to prompting, error, or throw/return semantics
- [x] No file under `AzVMAvailability/` is touched — this is a `tools/` reporting script only
- [x] Dashboard output is byte-identical whenever every array is non-empty; the change only affects the previously-broken empty case

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code quality (refactoring, comments, tests — no behavior change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Quality Checklist

- [x] **PR markdown renders correctly** — no literal escaped newline sequences in title or body
- [x] **No AI instructional comments** — `Validate-Script.ps1` check 4 PASS
- [x] **No empty catch blocks** — none added
- [x] **No magic numbers** — the only literal is the `0` count guard, which is the condition being tested
- [x] **Version strings in sync** — check 5 reports all references match v3.0.2; this PR changes no version string
- [x] **PSScriptAnalyzer clean** — check 2 PASS, 66 files, no warnings or errors
- [x] **Pester tests pass** — 611 passed, 0 failed
- [x] **Syntax valid** — check 1 PASS
- [x] **New functions have Pester test coverage** — the restored helper is a four-line guard in a reporting script with no test harness; correctness is evidenced by the before/after emitted-JavaScript comparison above
- [x] **CHANGELOG.md updated** — `### Fixed` entry under `## [Unreleased]`
- [x] **Release/tag plan prepared for this version bump** — N/A; `ScriptVersion` and `ModuleVersion` are unchanged at v3.0.2, so this PR produces no tag or release

## Validation

- [x] Ran `tools/Validate-Script.ps1` — 8 of 8 checks PASS, exit code 0
- [x] Verified the empty-array behavior directly on PowerShell 7.6.4 rather than relying on documented `-AsArray` semantics

## Follow-up

Once this merges, `sync-traffic-infra.yml` needs a re-run so the downstream sync PRs carry the corrected generator. The existing sync PRs should not be merged until then.

Also includes accumulated Copilot review triage entries in `artifacts/copilot-review-log.md` for PRs #176, #177, #180, #173, and #172.
